### PR TITLE
StarlingX Field and URL updates

### DIFF
--- a/starlingx/inventory/v1/cpus/results.go
+++ b/starlingx/inventory/v1/cpus/results.go
@@ -42,15 +42,15 @@ type CPU struct {
 	// Processor is the processor package number.  A host usually has 1 or 2
 	// processors but that number could be higher.  Each is usually associated
 	// to a seperate NUMA socket.
-	Processor int `json:"processor"`
+	Processor int `json:"numa_node"`
 
 	// LogicalCore is the logical core number of the core.  If hypher-threading
 	// is disabled then this may map directly to the physical core number.
-	LogicalCore int `json:"logical_core"`
+	LogicalCore int `json:"cpu"`
 
 	// PhysicalCore is the physical core number.  If hyper-threading is enabled
 	// then multiple logical cores will share the same physical core.
-	PhysicalCore int `json:"physical_core"`
+	PhysicalCore int `json:"core"`
 
 	// Thread is the hyper-threading thread number.
 	Thread int `json:"thread"`

--- a/starlingx/inventory/v1/interfaceDataNetworks/requests.go
+++ b/starlingx/inventory/v1/interfaceDataNetworks/requests.go
@@ -101,3 +101,9 @@ func ListInterfaceDataNetworks(c *gophercloud.ServiceClient, hostid string) ([]I
 
 	return objs, err
 }
+
+// Get retrieves a specific interfaceDataNetwork based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) (r GetResult) {
+	_, r.Err = c.Get(getURL(c, id), &r.Body, nil)
+	return r
+}

--- a/starlingx/inventory/v1/interfaceDataNetworks/results.go
+++ b/starlingx/inventory/v1/interfaceDataNetworks/results.go
@@ -50,11 +50,11 @@ type InterfaceDataNetwork struct {
 
 	// DataNetworkUUID defines the system assigned unique UUID of the associated
 	// data network.
-	DataNetworkUUID string `json:"network_uuid"`
+	DataNetworkUUID string `json:"datanetwork_uuid"`
 
 	// DataNetworkID defines the system assigned sequential integer id value of
 	// the associated network.
-	DataNetworkID int `json:"network_id"`
+	DataNetworkID int `json:"datanetwork_id"`
 
 	// DataNetworkType defines the type value assigned to the data network.
 	DataNetworkType string `json:"network_type"`

--- a/starlingx/inventory/v1/interfaceDataNetworks/urls.go
+++ b/starlingx/inventory/v1/interfaceDataNetworks/urls.go
@@ -24,3 +24,7 @@ func createURL(c *gophercloud.ServiceClient) string {
 func deleteURL(c *gophercloud.ServiceClient, id string) string {
 	return resourceURL(c, id)
 }
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/starlingx/inventory/v1/storagetiers/urls.go
+++ b/starlingx/inventory/v1/storagetiers/urls.go
@@ -6,7 +6,7 @@ package storagetiers
 import "github.com/gophercloud/gophercloud"
 
 func resourceURL(c *gophercloud.ServiceClient, id string) string {
-	return c.ServiceURL("storage_backend", id)
+	return c.ServiceURL("storage_tiers", id)
 }
 
 func rootURL(c *gophercloud.ServiceClient) string {

--- a/testhelper/http_responses.go
+++ b/testhelper/http_responses.go
@@ -91,7 +91,7 @@ func TestJSONRequest(t *testing.T, r *http.Request, expected string) {
 		t.Errorf("Unable to parse request body as JSON: %v", err)
 	}
 
-	CheckJSONEquals(t, expected, actualJSON)
+	CheckJSONEqualsUnordered(t, expected, actualJSON)
 }
 
 func normalizeMultipartBoundary(body string) string {


### PR DESCRIPTION
Update field names and URLs to match API reference and StarlingX system command.

**cpus:**
changed fields:
processor -> numa_node
logical_core -> cpu
physical_core -> core

**interfaceDataNetworks:**
added GET url and function
changed fields:
network_uuid -> datanetwork_uuid
network_id -> datanetwork_id

**storage tiers:**
updated resource url