### PR TITLE
Add support storage backend capabilities

### DIFF
--- a/starlingx/inventory/v1/storagebackends/results.go
+++ b/starlingx/inventory/v1/storagebackends/results.go
@@ -42,6 +42,8 @@ type DeleteResult struct {
 // Capabilities defines the set of system or resource capabilities associated to
 // this resource.
 type Capabilities struct {
+	Replication string `json:"replication,omitempty"`
+	MinReplication string `json:"min_replication,omitempty"`
 }
 
 // StorageBackend defines the data associated to a single StorageBackend


### PR DESCRIPTION
Add support for retrieving replication and min_replication
from the storage backend.

These parameters are only applicable to ceph, but ceph
is the only supported backend on starlingx.

Signed-off-by: Stefan Dinescu <stefan.dinescu@windriver.com>
