### PR TITLE
Add support for multiple CA certificates

### DIFF
--- a/starlingx/inventory/v1/certificates/results.go
+++ b/starlingx/inventory/v1/certificates/results.go
@@ -25,7 +25,7 @@ type CreateResult struct {
 	commonResult
 }
 
-func (r CreateResult) Extract() (*Certificate, error) {
+func (r CreateResult) Extract() ([]*Certificate, error) {
 	var s CreateResponse
 	err := r.ExtractInto(&s)
 	if s.Error != "" {
@@ -52,7 +52,7 @@ type DeleteResult struct {
 // CertificateResponse defines a special wrapper to deal with the non-standard
 // response format of certificate install API.
 type CreateResponse struct {
-	Certificate *Certificate `json:"certificates,omitempty"`
+	Certificate []*Certificate `json:"certificates,omitempty"`
 	Body        string       `json:"body"`
 	Success     string       `json:"success"`
 	Error       string       `json:"error"`


### PR DESCRIPTION
Update certificate parameters to accept a list instead of a single cert
for compatibility with the system API

Signed-off-by: Melissa Wang <melissa.wang@windriver.com>
