### PR TITLE
Add support for VF type interface rate limiting

### DIFF
--- a/starlingx/inventory/v1/interfaces/requests.go
+++ b/starlingx/inventory/v1/interfaces/requests.go
@@ -74,6 +74,7 @@ type InterfaceOpts struct {
 	Uses             *[]string `json:"uses,omitempty" mapstructure:"uses"`
 	UsesModify       *[]string `json:"usesmodify,omitempty" mapstructure:"usesmodify"`
 	PTPRole          *string   `json:"ptp_role,omitempty" mapstructure:"ptp_role"`
+	MaxTxRate        *int      `json:"max_tx_rate,omitempty" mapstructure:"max_tx_rate"`
 }
 
 // ListOptsBuilder allows extensions to add additional parameters to the

--- a/starlingx/inventory/v1/interfaces/results.go
+++ b/starlingx/inventory/v1/interfaces/results.go
@@ -109,6 +109,10 @@ type Interface struct {
 
 	// PTPRole is the configuration of the interface as ptp master, slave, or none.
 	PTPRole *string `json:"ptp_role,omitempty"`
+
+	// VFCount is the number of SRIOV VF interfaces configured.
+	MaxTxRate *int `json:"max_tx_rate,omitempty"`
+
 }
 
 // InterfacePage is the page returned by a pager when traversing over a


### PR DESCRIPTION
Add MaxTxRate in InterfaceOpts for request
Add MaxTxRate in Interface for result

Signed-off-by: Litao Gao <litao.gao@windriver.com>

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[PUT ISSUE NUMBER HERE]

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[PUT URLS HERE]
