### PR TITLE
Add bond option primary_reselect

### DIFF
--- a/starlingx/inventory/v1/interfaces/requests.go
+++ b/starlingx/inventory/v1/interfaces/requests.go
@@ -69,6 +69,7 @@ type InterfaceOpts struct {
 	DataNetworks     *[]string `json:"datanetworks,omitempty" mapstructure:"datanetworks"`
 	AEMode           *string   `json:"aemode,omitempty" mapstructure:"aemode"`
 	AETransmitHash   *string   `json:"txhashpolicy,omitempty" mapstructure:"txhashpolicy"`
+	AEPrimReselect   *string   `json:"primary_reselect,omitempty" mapstructure:"primary_reselect"`
 	VFCount          *int      `json:"sriov_numvfs,omitempty" mapstructure:"sriov_numvfs"`
 	VFDriver         *string   `json:"sriov_vf_driver,omitempty" mapstructure:"sriov_vf_driver"`
 	Uses             *[]string `json:"uses,omitempty" mapstructure:"uses"`

--- a/starlingx/inventory/v1/interfaces/results.go
+++ b/starlingx/inventory/v1/interfaces/results.go
@@ -93,6 +93,10 @@ type Interface struct {
 	// the interface is a Bond interface.
 	AETransmitHash *string `json:"txhashpolicy,omitempty"`
 
+	// AEPrimReselect is the primary reselection policy assigned to the interface if
+	// the interface is a Bond interface.
+	AEPrimReselect *string `json:"primary_reselect,omitempty"`
+
 	// VFCount is the number of SRIOV VF interfaces configured.
 	VFCount *int `json:"sriov_numvfs,omitempty"`
 
@@ -112,7 +116,6 @@ type Interface struct {
 
 	// VFCount is the number of SRIOV VF interfaces configured.
 	MaxTxRate *int `json:"max_tx_rate,omitempty"`
-
 }
 
 // InterfacePage is the page returned by a pager when traversing over a


### PR DESCRIPTION
This update is to allow the option primary_reselect configurable for
aggregated ethernet interface. The option is to prevent reverting
between the primary slave and other slaves.

Signed-off-by: Teresa Ho <teresa.ho@windriver.com>
