### PR TITLE
Add storage_backend network field

### DIFF
--- a/starlingx/inventory/v1/storagebackends/requests.go
+++ b/starlingx/inventory/v1/storagebackends/requests.go
@@ -16,6 +16,7 @@ type StorageBackendOpts struct {
 	State        *string                 `json:"state,omitempty" mapstructure:"state"`
 	Task         *string                 `json:"task,omitempty" mapstructure:"task"`
 	Services     *string                 `json:"services,omitempty" mapstructure:"services"`
+	Network      *string                 `json:"network,omitempty" mapstructure:"network"`
 	Capabilities *map[string]interface{} `json:"capabilities,omitempty" mapstructure:"capabilities"`
 }
 

--- a/starlingx/inventory/v1/storagebackends/results.go
+++ b/starlingx/inventory/v1/storagebackends/results.go
@@ -55,6 +55,7 @@ type StorageBackend struct {
 	State        string       `json:"state"`
 	Task         string       `json:"task"`
 	Services     string       `json:"services"`
+	Network      string       `json:"network"`
 	Capabilities Capabilities `json:"capabilities"`
 
 	// CreatedAt defines the timestamp at which the resource was created.


### PR DESCRIPTION
Add the network field to storage_backend endpoint.
The field is only used by ceph at the moment.

Signed-off-by: Dan Voiculeasa <dan.voiculeasa@windriver.com>

Change needed for:
https://storyboard.openstack.org/#!/story/2008843
Specific: https://review.opendev.org/c/starlingx/config/+/787426