### PR TITLE
Create file system

### DIFF
--- a/starlingx/inventory/v1/hostFilesystems/requests.go
+++ b/starlingx/inventory/v1/hostFilesystems/requests.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
 
 package hostFilesystems
 
@@ -18,6 +18,12 @@ const (
 type FileSystemOpts struct {
 	Name string `json:"name,omitempty" mapstructure:"name"`
 	Size int    `json:"size,omitempty" mapstructure:"size"`
+}
+
+type CreateFileSystemOpts struct {
+	Name     string `json:"name,omitempty" mapstructure:"name"`
+	Size     int    `json:"size,omitempty" mapstructure:"size"`
+	HostUUID string `json:"ihost_uuid,omitempty" mapstructure:"ihost_uuid"`
 }
 
 // ListOptsBuilder allows extensions to add additional parameters to the
@@ -112,4 +118,24 @@ func ListFileSystems(c *gophercloud.ServiceClient, hostid string) ([]FileSystem,
 	}
 
 	return objs, err
+}
+
+// Create accepts a CreateOpts struct and creates a new filesystem using the
+// values provided.
+func Create(client *gophercloud.ServiceClient, opts CreateFileSystemOpts) (r CreateResult) {
+	reqBody, err := inventoryv1.ConvertToCreateMap(opts)
+	if err != nil {
+		r.Err = err
+		return
+	}
+	_, r.Err = client.Post(createURL(client), reqBody, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	return
+}
+
+// Delete accepts a unique ID and deletes the filesystem associated with it.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, id), nil)
+	return
 }

--- a/starlingx/inventory/v1/hostFilesystems/requests.go
+++ b/starlingx/inventory/v1/hostFilesystems/requests.go
@@ -126,16 +126,16 @@ func Create(client *gophercloud.ServiceClient, opts CreateFileSystemOpts) (r Cre
 	reqBody, err := inventoryv1.ConvertToCreateMap(opts)
 	if err != nil {
 		r.Err = err
-		return
+		return r
 	}
 	_, r.Err = client.Post(createURL(client), reqBody, &r.Body, &gophercloud.RequestOpts{
 		OkCodes: []int{200, 201, 202},
 	})
-	return
+	return r
 }
 
 // Delete accepts a unique ID and deletes the filesystem associated with it.
 func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
 	_, r.Err = c.Delete(deleteURL(c, id), nil)
-	return
+	return r
 }

--- a/starlingx/inventory/v1/hostFilesystems/results.go
+++ b/starlingx/inventory/v1/hostFilesystems/results.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
 
 package hostFilesystems
 
@@ -24,8 +24,18 @@ type GetResult struct {
 	commonResult
 }
 
-// CreateResult represents the result of an update operation.
+// UpdateResult represents the result of an update operation.
 type UpdateResult struct {
+	gophercloud.ErrResult
+}
+
+// CreateResult represents the result of an Create operation.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
 	gophercloud.ErrResult
 }
 

--- a/starlingx/inventory/v1/hostFilesystems/testing/fixtures.go
+++ b/starlingx/inventory/v1/hostFilesystems/testing/fixtures.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
 
 package testing
 

--- a/starlingx/inventory/v1/hostFilesystems/testing/fixtures.go
+++ b/starlingx/inventory/v1/hostFilesystems/testing/fixtures.go
@@ -5,10 +5,11 @@ package testing
 
 import (
 	"fmt"
-	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/hostFilesystems"
-	"github.com/gophercloud/gophercloud/testhelper/client"
 	"net/http"
 	"testing"
+
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/hostFilesystems"
+	"github.com/gophercloud/gophercloud/testhelper/client"
 
 	th "github.com/gophercloud/gophercloud/testhelper"
 )
@@ -127,5 +128,30 @@ func HandleFileSystemUpdateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestJSONRequest(t, r, `[ [ { "op": "replace", "path": "/name", "value": "Derp"  }, { "op": "replace", "path": "/size", "value": 50 } ] ]`)
 		fmt.Fprintf(w, FileSystemSingleBody)
+	})
+}
+
+func HandleFileSystemDeletionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/host_fs/1a43b9e1-6360-46c1-adbe-81987a732e94", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func HandleFileSystemCreationSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/host_fs", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+          "name": "Derp",
+          "ihost_uuid": "d99637e9-5451-45c6-98f4-f18968e43e91",
+          "size": 40
+        }`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
 	})
 }

--- a/starlingx/inventory/v1/hostFilesystems/testing/requests_test.go
+++ b/starlingx/inventory/v1/hostFilesystems/testing/requests_test.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
 
 package testing
 

--- a/starlingx/inventory/v1/hostFilesystems/testing/requests_test.go
+++ b/starlingx/inventory/v1/hostFilesystems/testing/requests_test.go
@@ -8,8 +8,9 @@ import (
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/hostFilesystems"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 
-	th "github.com/gophercloud/gophercloud/testhelper"
 	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 func TestListFileSystems(t *testing.T) {
@@ -88,4 +89,34 @@ func TestUpdateFileSystem(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)
 	}
+}
+
+func TestCreate(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleFileSystemCreationSuccessfully(t, FileSystemSingleBody)
+	name := "Derp"
+	size := 40
+	hostUUID := "d99637e9-5451-45c6-98f4-f18968e43e91"
+	options := hostFilesystems.CreateFileSystemOpts{
+		Size:     size,
+		HostUUID: hostUUID,
+		Name:     name,
+	}
+	actual, err := hostFilesystems.Create(client.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, actual.Size, 40)
+	th.AssertEquals(t, actual.ID, "1a43b9e1-6360-46c1-adbe-81987a732e94")
+}
+
+func TestDelete(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleFileSystemDeletionSuccessfully(t)
+
+	res := hostFilesystems.Delete(client.ServiceClient(), "1a43b9e1-6360-46c1-adbe-81987a732e94")
+	th.AssertNoErr(t, res.Err)
 }

--- a/starlingx/inventory/v1/hostFilesystems/urls.go
+++ b/starlingx/inventory/v1/hostFilesystems/urls.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2022 Wind River Systems, Inc. */
 
 package hostFilesystems
 
@@ -23,4 +23,12 @@ func listURL(c *gophercloud.ServiceClient, hostid string) string {
 
 func updateURL(c *gophercloud.ServiceClient, hostid string) string {
 	return c.ServiceURL("ihosts", hostid, "host_fs", "update_many")
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("host_fs", id)
 }


### PR DESCRIPTION
This commit add support to create/delete filesystem(currently only allowed file system: "instances" and "image-conversion" restricted by sysinv).

Test passed:
Introduce in the DM, remove the workaround from the DM,  and deployed a storage lab with  add additional file system "instances"  configured on the compute nodes