### PR TITLE
Support for starlingx ihost/<uuid>/kernel

### DIFF
--- a/starlingx/inventory/v1/kernel/doc.go
+++ b/starlingx/inventory/v1/kernel/doc.go
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+// Package kernel contains functionality for working with System Inventory
+// kernel resources.
+package kernel

--- a/starlingx/inventory/v1/kernel/requests.go
+++ b/starlingx/inventory/v1/kernel/requests.go
@@ -1,0 +1,32 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+package kernel
+
+import (
+	"github.com/gophercloud/gophercloud"
+	common "github.com/gophercloud/gophercloud/starlingx"
+)
+
+type KernelOpts struct {
+	Kernel *string `json:"kernel_provisioned" mapstructure:"kernel_provisioned"`
+}
+
+// Get retrieves a specific Kernel based on the host's unique ID.
+func Get(c *gophercloud.ServiceClient, hostid string) (r GetResult) {
+	// Send GET request to API
+	_, r.Err = c.Get(getURL(c, hostid), &r.Body, nil)
+	return r
+}
+
+// Update accepts an array of KernelOpts and updates the specified host kernel
+func Update(c *gophercloud.ServiceClient, hostid string, opts KernelOpts) (r UpdateResult) {
+	reqBody, err := common.ConvertToPatchMap(opts, common.ReplaceOp)
+	if err != nil {
+		r.Err = err
+	} else {
+		// Send PATCH request to API
+		_, r.Err = c.Patch(updateURL(c, hostid), reqBody, &r.Body, nil)
+	}
+	return r
+}

--- a/starlingx/inventory/v1/kernel/results.go
+++ b/starlingx/inventory/v1/kernel/results.go
@@ -1,0 +1,43 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+package kernel
+
+import (
+	"github.com/gophercloud/gophercloud"
+)
+
+// Extract interprets any commonResult as an Kernel.
+func (r commonResult) Extract() (*Kernel, error) {
+	var s Kernel
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation.
+type UpdateResult struct {
+	commonResult
+}
+
+type Kernel struct {
+	// ID of the host
+	HostID string `json:"ihost_uuid"`
+
+	// The hostname
+	Hostname string `json:"hostname"`
+
+	// The provisioned kernel
+	ProvisionedKernel string `json:"kernel_provisioned"`
+
+	// The running kernel
+	RunningKernel string `json:"kernel_running"`
+}

--- a/starlingx/inventory/v1/kernel/testing/fixtures.go
+++ b/starlingx/inventory/v1/kernel/testing/fixtures.go
@@ -1,0 +1,114 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/kernel"
+	th "github.com/gophercloud/gophercloud/testhelper"
+	fake "github.com/gophercloud/gophercloud/testhelper/client"
+)
+
+var (
+	TestHostUUID = "68d437d4-7381-4ad7-92aa-a3fe018ee803"
+	KernelHerp   = kernel.Kernel{
+		HostID:            TestHostUUID,
+		Hostname:          "controller-0",
+		ProvisionedKernel: "standard",
+		RunningKernel:     "standard",
+	}
+	KernelDerp = kernel.Kernel{
+		HostID:            TestHostUUID,
+		Hostname:          "controller-0",
+		ProvisionedKernel: "lowlatency",
+		RunningKernel:     "standard",
+	}
+)
+
+const KernelBody = `
+{
+	"ihost_uuid": "68d437d4-7381-4ad7-92aa-a3fe018ee803",
+	"hostname": "controller-0",
+	"kernel_provisioned": "standard",
+	"kernel_running": "standard",
+	"links": [
+		{
+			"href": "http://192.168.204.1:6385/v1/ihosts/68d437d4-7381-4ad7-92aa-a3fe018ee803/kernel",
+			"rel": "self"
+		},
+		{
+			"href": "http://192.168.204.1:6385/ihosts/68d437d4-7381-4ad7-92aa-a3fe018ee803/kernel",
+			"rel": "bookmark"
+		}
+	]
+}
+`
+const KernelBodyUpdated = `
+{
+	"ihost_uuid": "68d437d4-7381-4ad7-92aa-a3fe018ee803",
+	"hostname": "controller-0",
+	"kernel_provisioned": "lowlatency",
+	"kernel_running": "standard",
+	"links": [
+		{
+			"href": "http://192.168.204.1:6385/v1/ihosts/68d437d4-7381-4ad7-92aa-a3fe018ee803/kernel",
+			"rel": "self"
+		},
+		{
+			"href": "http://192.168.204.1:6385/ihosts/68d437d4-7381-4ad7-92aa-a3fe018ee803/kernel",
+			"rel": "bookmark"
+		}
+	]
+}
+`
+
+const KernelUpdateRequest = `
+[
+	{
+		"op": "replace",
+		"path": "/kernel_provisioned",
+		"value": "lowlatency"
+	}
+]
+`
+
+func makeUrl(hostid string) string {
+	var sb strings.Builder
+	fmt.Fprintf(&sb, "/ihosts/%s/kernel", hostid)
+	return sb.String()
+}
+
+func HandleKernelGetSuccessfully(t *testing.T) {
+	url := makeUrl(TestHostUUID)
+	th.Mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, KernelBody)
+	})
+}
+
+func HandleKernelUpdateSuccessfully(t *testing.T) {
+	url := makeUrl(TestHostUUID)
+	th.Mux.HandleFunc(url, func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", fake.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, KernelUpdateRequest)
+
+		w.Header().Add("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+
+		fmt.Fprint(w, KernelBodyUpdated)
+	})
+}

--- a/starlingx/inventory/v1/kernel/testing/requests_test.go
+++ b/starlingx/inventory/v1/kernel/testing/requests_test.go
@@ -1,0 +1,41 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+package testing
+
+import (
+	"testing"
+
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/kernel"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestGetKernel(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleKernelGetSuccessfully(t)
+
+	client := client.ServiceClient()
+	actual, err := kernel.Get(client, TestHostUUID).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, KernelHerp, *actual)
+}
+
+func TestModifyKernel(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleKernelUpdateSuccessfully(t)
+
+	newKernel := "lowlatency"
+	actual, err := kernel.Update(client.ServiceClient(), TestHostUUID,
+		kernel.KernelOpts{Kernel: &newKernel}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update error: %v", err)
+	}
+	th.CheckDeepEquals(t, KernelDerp, *actual)
+}

--- a/starlingx/inventory/v1/kernel/urls.go
+++ b/starlingx/inventory/v1/kernel/urls.go
@@ -1,0 +1,18 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+package kernel
+
+import "github.com/gophercloud/gophercloud"
+
+func resourceURL(c *gophercloud.ServiceClient, hostid string) string {
+	return c.ServiceURL("ihosts", hostid, "kernel")
+}
+
+func getURL(c *gophercloud.ServiceClient, hostid string) string {
+	return resourceURL(c, hostid)
+}
+
+func updateURL(c *gophercloud.ServiceClient, hostid string) string {
+	return resourceURL(c, hostid)
+}


### PR DESCRIPTION
This commit adds support for host kernel configuration in starlingx starlingx/config sysinv added REST API /v1/ihosts/\<uuid\>/kernel:
 - GET
 - PATCH

Adds:
- support to configure starlingx host kernel
- UT for host kernel api in gophercloud

### Test Plan:

### Testing on starlingx AIO-SX - VM

- update kernel parameter in deployment-config.yaml
- kubectl apply -f deployment-config.yaml
- verify new kernel values system host-kernel-show <hostname>

### starlingx/config API References:
https://github.com/starlingx/config/blob/master/sysinv/sysinv/sysinv/sysinv/api/controllers/v1/kernel.py
