### PR TITLE
Create oam network API

### DIFF
--- a/starlingx/inventory/v1/oamNetworks/doc.go
+++ b/starlingx/inventory/v1/oamNetworks/doc.go
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+// Package oam networks contains functionality for working with System Inventory
+// platform network resources.
+package oamNetworks

--- a/starlingx/inventory/v1/oamNetworks/requests.go
+++ b/starlingx/inventory/v1/oamNetworks/requests.go
@@ -1,0 +1,108 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+package oamNetworks
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+	common "github.com/gophercloud/gophercloud/starlingx"
+)
+
+type OAMNetworkOpts struct {
+	OAMSubnet     *string `json:"oam_subnet,omitempty" mapstructure:"oam_subnet,omitempty"`
+	OAMGatewayIP  *string `json:"oam_gateway_ip,omitempty" mapstructure:"oam_gateway_ip,omitempty"`
+	OAMFloatingIP *string `json:"oam_floating_ip,omitempty" mapstructure:"oam_floating_ip,omitempty"`
+	OAMC0IP       *string `json:"oam_c0_ip,omitempty" mapstructure:"oam_c0_ip,omitempty"`
+	OAMC1IP       *string `json:"oam_c1_ip,omitempty" mapstructure:"oam_c1_ip,omitempty"`
+	OAMStartIP    *string `json:"oam_start_ip,omitempty" mapstructure:"oam_start_ip,omitempty"`
+	OAMEndIP      *string `json:"oam_end_ip,omitempty" mapstructure:"oam_end_ip,omitempty"`
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToOAMNetworkListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the noam network attributes you want to see returned. SortKey allows you to sort
+// by a particular oam network attribute. SortDir sets the direction, and is either
+// `asc' or `desc'. Marker and Limit are used for pagination.
+type ListOpts struct {
+	Marker  string `q:"marker"`
+	Limit   int    `q:"limit"`
+	SortKey string `q:"sort_key"`
+	SortDir string `q:"sort_dir"`
+}
+
+// ToOAMNetworkListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToOAMNetworkListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// List retrieves a list of iextoams
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToOAMNetworkListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return OAMNetworkPage{pagination.LinkedPageBase{PageResult: r}}
+	})
+}
+
+// Get retrieves a specific oam network based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) GetResult {
+	var res GetResult
+	_, res.Err = c.Get(getURL(c, id), &res.Body, nil)
+	return res
+}
+
+// Update accepts a PatchOpts struct and updates an existing oam network using the
+// values provided. For more information, see the Create function.
+func Update(c *gophercloud.ServiceClient, id string, opts OAMNetworkOpts) (r UpdateResult) {
+	reqBody, err := common.ConvertToPatchMap(opts, common.ReplaceOp)
+	if err != nil {
+		r.Err = err
+		return r
+	}
+
+	// Send request to API
+	_, r.Err = c.Patch(updateURL(c, id), reqBody, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201},
+	})
+
+	return r
+}
+
+// ListNetworks is a convenience function to list and extract the entire list
+// of platform networks
+func ListNetworks(c *gophercloud.ServiceClient) ([]OAMNetwork, error) {
+	pages, err := List(c, nil).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	empty, err := pages.IsEmpty()
+	if empty || err != nil {
+		return nil, err
+	}
+
+	objs, err := ExtractOAMNetworks(pages)
+	if err != nil {
+		return nil, err
+	}
+
+	return objs, err
+}

--- a/starlingx/inventory/v1/oamNetworks/results.go
+++ b/starlingx/inventory/v1/oamNetworks/results.go
@@ -1,0 +1,129 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+package oamNetworks
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Extract interprets any commonResult as an Image.
+func (r commonResult) Extract() (*OAMNetwork, error) {
+	var s OAMNetwork
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	commonResult
+}
+
+// CreateResult represents the result of an update operation.
+type CreateResult struct {
+	commonResult
+}
+
+// UpdateResult represents the result of an update operation.
+type UpdateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of an delete operation.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// Network defines the data associated to a single network instance.
+type OAMNetwork struct {
+	// Unique UUID for this extoam
+	UUID string `json:"uuid"`
+
+	// Represent the oam subnet.
+	OAMSubnet string `json:"oam_subnet"`
+
+	// Represent the oam gateway IP.
+	OAMGatewayIP string `json:"oam_gateway_ip"`
+
+	// Represent the oam floating IP.
+	OAMFloatingIP string `json:"oam_floating_ip"`
+
+	// Represent the oam controller-0 IP address.
+	OAMC0IP string `json:"oam_c0_ip"`
+
+	// Represent the oam controller-1 IP address.
+	OAMC1IP string `json:"oam_c1_ip"`
+
+	// Represent the oam network start IP address.
+	OAMStartIP string `json:"oam_start_ip"`
+
+	// Represent the oam network end IP address.
+	OAMEndIP string `json:"oam_end_ip"`
+
+	// Represents whether in region_config. True=region_config
+	RegionConfig bool `json:"region_config"`
+
+	// Represent the action on the OAM network.
+	Action string `json:"action"`
+
+	// The isystemid that this iextoam belongs to.
+	ForISystemID int `json:"forisystemid"`
+
+	// The UUID of the system this extoam belongs to.
+	ForISystemUUID string `json:"isystem_uuid"`
+
+	// A list containing a self link and associated extoam links.
+	Links []gophercloud.Link `json:"links"`
+
+	// CreatedAt defines the timestamp at which the resource was created.
+	CreatedAt string `json:"created_at"`
+
+	// UpdatedAt defines the timestamp at which the resource was last updated.
+	UpdatedAt *string `json:"updated_at,omitempty"`
+}
+
+// OAMNetworkPage is the page returned by a pager when traversing over a
+// collection of networks.
+type OAMNetworkPage struct {
+	pagination.LinkedPageBase
+}
+
+// IsEmpty checks whether a OAMNetworkPage struct is empty.
+func (r OAMNetworkPage) IsEmpty() (bool, error) {
+	is, err := ExtractOAMNetworks(r)
+	return len(is) == 0, err
+}
+
+// NextPageURL is invoked when a paginated collection of oam networks has reached
+// the end of a page and the pager seeks to traverse over a new one. In order
+// to do this, it needs to construct the next page's URL.
+func (r OAMNetworkPage) NextPageURL() (string, error) {
+	var s struct {
+		Links []gophercloud.Link `json:"iextoams_links"`
+	}
+	err := r.ExtractInto(&s)
+	if err != nil {
+		return "", err
+	}
+	return gophercloud.ExtractNextURL(s.Links)
+}
+
+// ExtractOAMNetworks accepts a Page struct, specifically a OAMNetworkPage struct,
+// and extracts the elements into a slice of OAM Network structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractOAMNetworks(r pagination.Page) ([]OAMNetwork, error) {
+	var s struct {
+		OAMNetwork []OAMNetwork `json:"iextoams"`
+	}
+	err := (r.(OAMNetworkPage)).ExtractInto(&s)
+	return s.OAMNetwork, err
+}
+
+func ExtractOAMNetworksInto(r pagination.Page, v interface{}) error {
+	return r.(OAMNetworkPage).Result.ExtractIntoSlicePtr(v, "iextoams")
+}

--- a/starlingx/inventory/v1/oamNetworks/testing/fixtures.go
+++ b/starlingx/inventory/v1/oamNetworks/testing/fixtures.go
@@ -1,0 +1,121 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+package testing
+
+import (
+	"fmt"
+	"net/http"
+	"testing"
+
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/oamNetworks"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+var (
+	OAMNetworkHerp = oamNetworks.OAMNetwork{
+		UUID:           "fd5aaa82-b503-40e2-af45-9fc4411df7a0",
+		OAMSubnet:      "10.10.20.0/24",
+		OAMGatewayIP:   "10.10.20.1",
+		OAMFloatingIP:  "10.10.20.2",
+		OAMC0IP:        "10.10.20.3",
+		OAMC1IP:        "10.10.20.4",
+		OAMStartIP:     "10.10.20.1",
+		OAMEndIP:       "10.10.20.254",
+		RegionConfig:   false,
+		ForISystemUUID: "607671a2-15a7-4f97-9297-c4e1804cde12",
+		CreatedAt:      "2023-11-28T13:10:53.200531+00:00",
+		Links: []gophercloud.Link{
+			{
+				Href: "http://192.168.204.2:6385/v1/iextoams/fd5aaa82-b503-40e2-af45-9fc4411df7a0",
+				Rel:  "self",
+			},
+			{
+				Href: "http://192.168.204.2:6385/iextoams/fd5aaa82-b503-40e2-af45-9fc4411df7a0",
+				Rel:  "bookmark",
+			},
+		},
+		UpdatedAt: nil,
+	}
+	OAMNetworkDerp = oamNetworks.OAMNetwork{
+		UUID:          "727bd796-070f-40c2-8b9b-7ed674fd0fe7",
+		OAMSubnet:     "10.10.20.0/24",
+		OAMGatewayIP:  "10.10.20.1",
+		OAMFloatingIP: "10.10.20.5",
+		OAMC0IP:       "10.10.20.3",
+		OAMC1IP:       "10.10.20.4",
+	}
+)
+
+const OAMNetworkListBody = `
+{
+	"iextoams": [
+		{
+			"uuid": "fd5aaa82-b503-40e2-af45-9fc4411df7a0",
+			"oam_subnet": "10.10.20.0/24",
+			"oam_gateway_ip": "10.10.20.1",
+			"oam_floating_ip": "10.10.20.2",
+			"oam_c0_ip": "10.10.20.3",
+			"oam_c1_ip": "10.10.20.4",
+			"oam_start_ip": "10.10.20.1",
+			"oam_end_ip": "10.10.20.254",
+			"region_config": false,
+			"isystem_uuid": "607671a2-15a7-4f97-9297-c4e1804cde12",
+			"links": [
+				{
+					"href": "http://192.168.204.2:6385/v1/iextoams/fd5aaa82-b503-40e2-af45-9fc4411df7a0",
+					"rel": "self"
+				}, {
+					"href": "http://192.168.204.2:6385/iextoams/fd5aaa82-b503-40e2-af45-9fc4411df7a0",
+					"rel": "bookmark"
+				}
+			],
+			"created_at": "2023-11-28T13:10:53.200531+00:00",
+			"updated_at": null
+		}
+	]
+}
+`
+
+const SingleOAMNetworkBody = `
+{
+    "uuid": "727bd796-070f-40c2-8b9b-7ed674fd0fe7",
+	"oam_subnet": "10.10.20.0/24",
+	"oam_gateway_ip": "10.10.20.1",
+	"oam_floating_ip": "10.10.20.5",
+	"oam_c0_ip": "10.10.20.3",
+	"oam_c1_ip": "10.10.20.4"
+}
+`
+
+func HandleOAMNetworkListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/iextoam", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, OAMNetworkListBody)
+	})
+}
+
+func HandleOAMNetworkGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/iextoam/fd5aaa82-b503-40e2-af45-9fc4411df7a0", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, SingleOAMNetworkBody)
+	})
+}
+
+func HandleOAMNetworkUpdateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/iextoam/727bd796-070f-40c2-8b9b-7ed674fd0fe7", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `[ { "op": "replace", "path": "/oam_floating_ip", "value": "10.10.20.10" } ]`)
+		fmt.Fprint(w, SingleOAMNetworkBody)
+	})
+}

--- a/starlingx/inventory/v1/oamNetworks/testing/requests_test.go
+++ b/starlingx/inventory/v1/oamNetworks/testing/requests_test.go
@@ -1,0 +1,65 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+package testing
+
+import (
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/oamNetworks"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+func TestListOAMNetworks(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleOAMNetworkListSuccessfully(t)
+
+	pages := 0
+	err := oamNetworks.List(client.ServiceClient(), oamNetworks.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+		actual, err := oamNetworks.ExtractOAMNetworks(page)
+		if err != nil {
+			return false, err
+		}
+
+		th.CheckDeepEquals(t, OAMNetworkHerp, actual[0])
+
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}
+func TestGetNetwork(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleOAMNetworkGetSuccessfully(t)
+
+	client := client.ServiceClient()
+	actual, err := oamNetworks.Get(client, "fd5aaa82-b503-40e2-af45-9fc4411df7a0").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, OAMNetworkDerp, *actual)
+}
+
+func TestUpdateNetwork(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleOAMNetworkUpdateSuccessfully(t)
+
+	newFloatingIP := "10.10.20.10"
+	actual, err := oamNetworks.Update(client.ServiceClient(), "727bd796-070f-40c2-8b9b-7ed674fd0fe7", oamNetworks.OAMNetworkOpts{OAMFloatingIP: &newFloatingIP}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update error: %v", err)
+	}
+	th.CheckDeepEquals(t, OAMNetworkDerp, *actual)
+}

--- a/starlingx/inventory/v1/oamNetworks/urls.go
+++ b/starlingx/inventory/v1/oamNetworks/urls.go
@@ -1,0 +1,26 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2023 Wind River Systems, Inc. */
+
+package oamNetworks
+
+import "github.com/gophercloud/gophercloud"
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("iextoam", id)
+}
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("iextoam")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func updateURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}


### PR DESCRIPTION
This commit adds the oam network (iextoam) package to integrate with sysinv API.

Prior to starting a PR, please make sure you have read our
[contributor tutorial](https://github.com/gophercloud/gophercloud/tree/master/docs/contributor-tutorial).

Prior to a PR being reviewed, there needs to be a Github issue that the PR
addresses. Replace the brackets and text below with that issue number.

For #[PUT ISSUE NUMBER HERE]

Links to the line numbers/files in the OpenStack source code that support the
code in this PR:

[PUT URLS HERE]
