### PR TITLE
Support Controller-0 and Controller-1 IPs in Address Pool

### DIFF
--- a/starlingx/inventory/v1/addresspools/requests.go
+++ b/starlingx/inventory/v1/addresspools/requests.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2024 Wind River Systems, Inc. */
 
 package addresspools
 
@@ -10,13 +10,15 @@ import (
 )
 
 type AddressPoolOpts struct {
-	Name            *string     `json:"name,omitempty" mapstructure:"name"`
-	Network         *string     `json:"network,omitempty" mapstructure:"network"`
-	FloatingAddress *string     `json:"floating_address,omitempty" mapstructure:"floating_address,omitempty"`
-	Prefix          *int        `json:"prefix,omitempty" mapstructure:"prefix"`
-	Gateway         *string     `json:"gateway_address,omitempty" mapstructure:"gateway_address,omitempty"`
-	Order           *string     `json:"order,omitempty" mapstructure:"order"`
-	Ranges          *[][]string `json:"ranges,omitempty" mapstructure:"ranges"`
+	Name               *string     `json:"name,omitempty" mapstructure:"name"`
+	Network            *string     `json:"network,omitempty" mapstructure:"network"`
+	FloatingAddress    *string     `json:"floating_address,omitempty" mapstructure:"floating_address,omitempty"`
+	Controller0Address *string     `json:"controller0_address,omitempty" mapstructure:"controller0_address,omitempty"`
+	Controller1Address *string     `json:"controller1_address,omitempty" mapstructure:"controller1_address,omitempty"`
+	Prefix             *int        `json:"prefix,omitempty" mapstructure:"prefix"`
+	Gateway            *string     `json:"gateway_address,omitempty" mapstructure:"gateway_address,omitempty"`
+	Order              *string     `json:"order,omitempty" mapstructure:"order"`
+	Ranges             *[][]string `json:"ranges,omitempty" mapstructure:"ranges"`
 }
 
 // ListOptsBuilder allows extensions to add additional parameters to the

--- a/starlingx/inventory/v1/addresspools/results.go
+++ b/starlingx/inventory/v1/addresspools/results.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2024 Wind River Systems, Inc. */
 
 package addresspools
 
@@ -52,6 +52,12 @@ type AddressPool struct {
 
 	// FloatingAddress is the floating IPv4 or IPv6 network address value.
 	FloatingAddress string `json:"floating_address,omitempty"`
+
+	// Controller0Address is the controller-0 IPv4 or IPv6 network address value.
+	Controller0Address string `json:"controller0_address,omitempty"`
+
+	// Controller1Address is the controller-1 IPv4 or IPv6 network address value.
+	Controller1Address string `json:"controller1_address,omitempty"`
 
 	// Prefix is the numeric prefix length of the network.
 	Prefix int `json:"prefix"`

--- a/starlingx/inventory/v1/addresspools/testing/fixtures.go
+++ b/starlingx/inventory/v1/addresspools/testing/fixtures.go
@@ -14,22 +14,28 @@ import (
 
 var (
 	AddressPoolHerp = addresspools.AddressPool{
-		ID:      "727bd796-070f-40c2-8b9b-7ed674fd0fe7",
-		Name:    "management",
-		Prefix:  24,
-		Network: "192.168.204.0",
-		Gateway: nil,
-		Order:   "random",
-		Ranges:  [][]string{{"192.268.206.100", "192.168.204.254"}},
+		ID:                 "727bd796-070f-40c2-8b9b-7ed674fd0fe7",
+		Name:               "management",
+		Prefix:             24,
+		Network:            "192.168.204.0",
+		Gateway:            nil,
+		Order:              "random",
+		Ranges:             [][]string{{"192.268.206.100", "192.168.204.254"}},
+		FloatingAddress:    "192.168.204.2",
+		Controller0Address: "192.168.204.3",
+		Controller1Address: "192.168.204.4",
 	}
 	AddressPoolDerp = addresspools.AddressPool{
-		ID:      "123914e3-36e4-41a8-a702-d9f6e54d7140",
-		Name:    "pxeboot",
-		Prefix:  24,
-		Network: "169.254.202.0",
-		Gateway: nil,
-		Order:   "random",
-		Ranges:  [][]string{{"169.254.202.1", "169.254.202.254"}},
+		ID:                 "123914e3-36e4-41a8-a702-d9f6e54d7140",
+		Name:               "pxeboot",
+		Prefix:             24,
+		Network:            "169.254.202.0",
+		Gateway:            nil,
+		Order:              "random",
+		Ranges:             [][]string{{"169.254.202.1", "169.254.202.254"}},
+		FloatingAddress:    "169.254.202.2",
+		Controller0Address: "169.254.202.3",
+		Controller1Address: "169.254.202.4",
 	}
 )
 
@@ -46,6 +52,9 @@ const AddressPoolListBody = `
                     "192.168.204.254"
                 ]
             ],
+			"floating_address": "192.168.204.2",
+			"controller0_address": "192.168.204.3",
+			"controller1_address": "192.168.204.4",
             "prefix": 24,
             "order": "random",
             "uuid": "727bd796-070f-40c2-8b9b-7ed674fd0fe7"
@@ -60,6 +69,9 @@ const AddressPoolListBody = `
                     "169.254.202.254"
                 ]
             ],
+			"floating_address": "169.254.202.2",
+			"controller0_address": "169.254.202.3",
+			"controller1_address": "169.254.202.4",
             "prefix": 24,
             "order": "random",
             "uuid": "123914e3-36e4-41a8-a702-d9f6e54d7140"
@@ -79,6 +91,9 @@ const AddressPoolSingleBody = `
 			"169.254.202.254"
 		]
 	],
+	"floating_address": "169.254.202.2",
+	"controller0_address": "169.254.202.3",
+	"controller1_address": "169.254.202.4",
 	"prefix": 24,
 	"order": "random",
 	"uuid": "123914e3-36e4-41a8-a702-d9f6e54d7140"
@@ -125,6 +140,9 @@ func HandleAddressPoolCreationSuccessfully(t *testing.T, response string) {
 					"169.254.202.254"
 				]
 			],
+			"floating_address": "169.254.202.2",
+			"controller0_address": "169.254.202.3",
+			"controller1_address": "169.254.202.4",		
 			"prefix": 24,
 			"order": "random"
 		}`)

--- a/starlingx/inventory/v1/addresspools/testing/requests_test.go
+++ b/starlingx/inventory/v1/addresspools/testing/requests_test.go
@@ -79,13 +79,19 @@ func TestCreateAddressPool(t *testing.T) {
 	network := "169.254.202.0"
 	order := "random"
 	ranges := [][]string{{"169.254.202.1", "169.254.202.254"}}
-
+	floating_addr := "169.254.202.2"
+	c0_addr := "169.254.202.3"
+	c1_addr := "169.254.202.4"
+	
 	actual, err := addresspools.Create(client.ServiceClient(), addresspools.AddressPoolOpts{
-		Name:    &name,
-		Prefix:  &prefix,
-		Network: &network,
-		Order:   &order,
-		Ranges:  &ranges,
+		Name:               &name,
+		Prefix:             &prefix,
+		Network:            &network,
+		Order:              &order,
+		Ranges:             &ranges,
+		FloatingAddress:    &floating_addr,
+		Controller0Address: &c0_addr,
+		Controller1Address: &c1_addr,
 	}).Extract()
 	th.AssertNoErr(t, err)
 


### PR DESCRIPTION
This commit should enable read and update operations of controller-0 and controller-1 IP addresses with the address pool API.