### PR TITLE
Sysinv API Changes to Support Dual-Stack Networking

### DIFF
--- a/starlingx/inventory/v1/networkAddressPools/doc.go
+++ b/starlingx/inventory/v1/networkAddressPools/doc.go
@@ -1,0 +1,6 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2024 Wind River Systems, Inc. */
+
+// Package networkAddressPools contains functionality for working with System Inventory
+// network address pool resources.
+package networkAddressPools

--- a/starlingx/inventory/v1/networkAddressPools/requests.go
+++ b/starlingx/inventory/v1/networkAddressPools/requests.go
@@ -1,0 +1,112 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2024 Wind River Systems, Inc. */
+
+package networkAddressPools
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+	common "github.com/gophercloud/gophercloud/starlingx"
+)
+
+type NetworkAddressPoolOpts struct {
+	NetworkUUID     *string `json:"network_uuid,omitempty" mapstructure:"network_uuid"`
+	AddressPoolUUID *string `json:"addresspool_uuid,omitempty" mapstructure:"addresspool_uuid"`
+	NetworkName     *string `json:"network_name,omitempty" mapstructure:"network_name"`
+	AddressPoolName *string `json:"addresspool_name,omitempty" mapstructure:"addresspool_name"`
+}
+
+// ListOptsBuilder allows extensions to add additional parameters to the
+// List request.
+type ListOptsBuilder interface {
+	ToNetworkAddressPoolListQuery() (string, error)
+}
+
+// ListOpts allows the filtering and sorting of paginated collections through
+// the API. Filtering is achieved by passing in struct field values that map to
+// the network address pool attributes you want to see returned. SortKey allows
+// you to sort by a particular network address pool attribute. SortDir sets the
+// direction, and is either `asc' or `desc'. Marker and Limit are used for
+// pagination.
+type ListOpts struct {
+	Marker  string `q:"marker"`
+	Limit   int    `q:"limit"`
+	SortKey string `q:"sort_key"`
+	SortDir string `q:"sort_dir"`
+}
+
+// ToNetworkAddressPoolListQuery formats a ListOpts into a query string.
+func (opts ListOpts) ToNetworkAddressPoolListQuery() (string, error) {
+	q, err := gophercloud.BuildQueryString(opts)
+	if err != nil {
+		return "", err
+	}
+	return q.String(), nil
+}
+
+// List returns a Pager which allows you to iterate over a collection of
+// network address pools. It accepts a ListOpts struct, which allows you to filter and sort
+// the returned collection for greater efficiency.
+func List(c *gophercloud.ServiceClient, opts ListOptsBuilder) pagination.Pager {
+	url := listURL(c)
+	if opts != nil {
+		query, err := opts.ToNetworkAddressPoolListQuery()
+		if err != nil {
+			return pagination.Pager{Err: err}
+		}
+		url += query
+	}
+
+	return pagination.NewPager(c, url, func(r pagination.PageResult) pagination.Page {
+		return NetworkAddressPoolPage{pagination.SinglePageBase(r)}
+	})
+}
+
+// Get retrieves a specific network address pool based on its unique ID.
+func Get(c *gophercloud.ServiceClient, id string) GetResult {
+	var res GetResult
+	_, res.Err = c.Get(getURL(c, id), &res.Body, nil)
+	return res
+}
+
+// Create accepts a CreateOpts struct and creates a new NetworkAddressPool using the
+// values provided.
+func Create(c *gophercloud.ServiceClient, opts NetworkAddressPoolOpts) (r CreateResult) {
+	reqBody, err := common.ConvertToCreateMap(opts)
+	if err != nil {
+		r.Err = err
+		return r
+	}
+
+	_, r.Err = c.Post(createURL(c), reqBody, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	return r
+}
+
+// Delete accepts a unique ID and deletes the related resource.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, id), nil)
+	return r
+}
+
+// ListNetworkAddressPools is a convenience function to list and extract the entire list
+// of network address pools.
+func ListNetworkAddressPools(c *gophercloud.ServiceClient) ([]NetworkAddressPool, error) {
+	pages, err := List(c, nil).AllPages()
+	if err != nil {
+		return nil, err
+	}
+
+	empty, err := pages.IsEmpty()
+	if empty || err != nil {
+		return nil, err
+	}
+
+	objs, err := ExtractNetworkAddressPools(pages)
+	if err != nil {
+		return nil, err
+	}
+
+	return objs, err
+}

--- a/starlingx/inventory/v1/networkAddressPools/results.go
+++ b/starlingx/inventory/v1/networkAddressPools/results.go
@@ -1,0 +1,78 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2024 Wind River Systems, Inc. */
+
+package networkAddressPools
+
+import (
+	"github.com/gophercloud/gophercloud"
+	"github.com/gophercloud/gophercloud/pagination"
+)
+
+// Extract interprets any commonResult as an Image.
+func (r commonResult) Extract() (*NetworkAddressPool, error) {
+	var s NetworkAddressPool
+	err := r.ExtractInto(&s)
+	return &s, err
+}
+
+type commonResult struct {
+	gophercloud.Result
+}
+
+// GetResult represents the result of a get operation.
+type GetResult struct {
+	commonResult
+}
+
+// CreateResult represents the result of an update operation.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult represents the result of an delete operation.
+type DeleteResult struct {
+	gophercloud.ErrResult
+}
+
+// NetworkAddressPool defines the data associated to a single network address pool instance.
+type NetworkAddressPool struct {
+	// UUID is a system generated unique UUID for the network address pool
+	UUID string `json:"uuid"`
+
+	// NetworkUUID is the UUID of the network resource
+	NetworkUUID string `json:"network_uuid"`
+
+	// AddressPoolUUID is the UUID of the address pool resource
+	AddressPoolUUID string `json:"addresspool_uuid"`
+
+	// NetworkName is the name of network resource
+	NetworkName string `json:"network_name"`
+
+	// AddressPoolName is the name of the address pool resource
+	AddressPoolName string `json:"addresspool_name"`
+}
+
+// NetworkAddressPool is the page returned by a pager when traversing over a
+// collection of network address pools.
+type NetworkAddressPoolPage struct {
+	pagination.SinglePageBase
+}
+
+// IsEmpty checks whether a NetworkAddressPool struct is empty.
+func (r NetworkAddressPoolPage) IsEmpty() (bool, error) {
+	is, err := ExtractNetworkAddressPools(r)
+	return len(is) == 0, err
+}
+
+// ExtractNetworkAddressPools accepts a Page struct, specifically a NetworkAddressPool struct,
+// and extracts the elements into a slice of NetworkAddressPool structs. In other words,
+// a generic collection is mapped into a relevant slice.
+func ExtractNetworkAddressPools(r pagination.Page) ([]NetworkAddressPool, error) {
+	var s struct {
+		NetworkAddressPools []NetworkAddressPool `json:"network_addresspools"`
+	}
+
+	err := (r.(NetworkAddressPoolPage)).ExtractInto(&s)
+
+	return s.NetworkAddressPools, err
+}

--- a/starlingx/inventory/v1/networkAddressPools/testing/fixtures.go
+++ b/starlingx/inventory/v1/networkAddressPools/testing/fixtures.go
@@ -1,0 +1,107 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2024 Wind River Systems, Inc. */
+
+package testing
+
+import (
+	"fmt"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/networkAddressPools"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+	"net/http"
+	"testing"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+)
+
+var (
+	NetworkAddressPoolHerp = networkAddressPools.NetworkAddressPool{
+		UUID:            "11111111-a6e5-425e-9317-995da88d6694",
+		NetworkUUID:     "11111111-0000-425e-9317-995da88d6694",
+		AddressPoolUUID: "11111111-1111-425e-9317-995da88d6694",
+		NetworkName:     "oam",
+		AddressPoolName: "oam-ipv4",
+	}
+
+	NetworkAddressPoolDerp = networkAddressPools.NetworkAddressPool{
+		UUID:            "22222222-a6e5-425e-9317-995da88d6694",
+		NetworkUUID:     "22222222-0000-425e-9317-995da88d6694",
+		AddressPoolUUID: "22222222-1111-425e-9317-995da88d6694",
+		NetworkName:     "oam",
+		AddressPoolName: "oam-ipv6",
+	}
+)
+
+const NetworkAddressPoolListBody = `
+{
+    "network_addresspools": [
+        {
+			"uuid": "11111111-a6e5-425e-9317-995da88d6694",
+			"network_uuid": "11111111-0000-425e-9317-995da88d6694",
+			"addresspool_uuid": "11111111-1111-425e-9317-995da88d6694",
+			"network_name": "oam",
+			"addresspool_name": "oam-ipv4"
+		},
+		{
+			"uuid": "22222222-a6e5-425e-9317-995da88d6694",
+			"network_uuid": "22222222-0000-425e-9317-995da88d6694",
+			"addresspool_uuid": "22222222-1111-425e-9317-995da88d6694",
+			"network_name": "oam",
+			"addresspool_name": "oam-ipv6"
+		}
+    ]
+}
+`
+
+const SingleNetworkAddressPoolBody = `
+{
+	"uuid": "11111111-a6e5-425e-9317-995da88d6694",
+	"network_uuid": "11111111-0000-425e-9317-995da88d6694",
+	"addresspool_uuid": "11111111-1111-425e-9317-995da88d6694",
+	"network_name": "oam",
+	"addresspool_name": "oam-ipv4"
+}
+`
+
+func HandleNetworkAddressPoolListSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/network_addresspools", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, NetworkAddressPoolListBody)
+	})
+}
+
+func HandleNetworkAddressPoolGetSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/network_addresspools/11111111-a6e5-425e-9317-995da88d6694", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "GET")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, SingleNetworkAddressPoolBody)
+	})
+}
+
+func HandleNetworkAddressPoolDeletionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/network_addresspools/11111111-a6e5-425e-9317-995da88d6694", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
+	})
+}
+
+func HandleNetworkAddressPoolCreationSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/network_addresspools", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+          "network_uuid": "11111111-0000-425e-9317-995da88d6694",
+          "network_name": "oam",
+          "addresspool_uuid": "11111111-1111-425e-9317-995da88d6694",
+          "addresspool_name": "oam-ipv4"
+        }`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, response)
+	})
+}

--- a/starlingx/inventory/v1/networkAddressPools/testing/requests_test.go
+++ b/starlingx/inventory/v1/networkAddressPools/testing/requests_test.go
@@ -1,0 +1,98 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2024 Wind River Systems, Inc. */
+
+package testing
+
+import (
+	"github.com/gophercloud/gophercloud/pagination"
+	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/networkAddressPools"
+	"github.com/gophercloud/gophercloud/testhelper/client"
+
+	th "github.com/gophercloud/gophercloud/testhelper"
+	"testing"
+)
+
+func TestListNetworkAddressPools(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleNetworkAddressPoolListSuccessfully(t)
+
+	pages := 0
+	err := networkAddressPools.List(client.ServiceClient(), networkAddressPools.ListOpts{}).EachPage(func(page pagination.Page) (bool, error) {
+		pages++
+		actual, err := networkAddressPools.ExtractNetworkAddressPools(page)
+		if err != nil {
+			return false, err
+		}
+
+		if len(actual) != 2 {
+			t.Fatalf("Expected 2 network address pools, got %d", len(actual))
+		}
+		th.CheckDeepEquals(t, NetworkAddressPoolHerp, actual[0])
+		th.CheckDeepEquals(t, NetworkAddressPoolDerp, actual[1])
+
+		return true, nil
+	})
+
+	th.AssertNoErr(t, err)
+
+	if pages != 1 {
+		t.Errorf("Expected 1 page, saw %d", pages)
+	}
+}
+
+func TestListAllNetworkAddressPools(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleNetworkAddressPoolListSuccessfully(t)
+
+	network_address_pools, err := networkAddressPools.ListNetworkAddressPools(client.ServiceClient())
+	th.AssertNoErr(t, err)
+	th.CheckDeepEquals(t, NetworkAddressPoolHerp, network_address_pools[0])
+	th.CheckDeepEquals(t, NetworkAddressPoolDerp, network_address_pools[1])
+}
+
+func TestGetNetworkAddressPool(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleNetworkAddressPoolGetSuccessfully(t)
+
+	client := client.ServiceClient()
+	actual, err := networkAddressPools.Get(client, "11111111-a6e5-425e-9317-995da88d6694").Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Get error: %v", err)
+	}
+
+	th.CheckDeepEquals(t, NetworkAddressPoolHerp, *actual)
+}
+
+func TestCreateNetworkAddressPool(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleNetworkAddressPoolCreationSuccessfully(t, SingleNetworkAddressPoolBody)
+
+	network_name := "oam"
+	addresspool_name := "oam-ipv4"
+	network_uuid := "11111111-0000-425e-9317-995da88d6694"
+	addresspool_uuid := "11111111-1111-425e-9317-995da88d6694"
+
+	actual, err := networkAddressPools.Create(client.ServiceClient(), networkAddressPools.NetworkAddressPoolOpts{
+		NetworkUUID:     &network_uuid,
+		AddressPoolUUID: &addresspool_uuid,
+		NetworkName:     &network_name,
+		AddressPoolName: &addresspool_name,
+	}).Extract()
+
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, NetworkAddressPoolHerp, *actual)
+}
+
+func TestDeleteNetwork(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleNetworkAddressPoolDeletionSuccessfully(t)
+
+	res := networkAddressPools.Delete(client.ServiceClient(), "11111111-a6e5-425e-9317-995da88d6694")
+	th.AssertNoErr(t, res.Err)
+}

--- a/starlingx/inventory/v1/networkAddressPools/urls.go
+++ b/starlingx/inventory/v1/networkAddressPools/urls.go
@@ -1,0 +1,30 @@
+/* SPDX-License-Identifier: Apache-2.0 */
+/* Copyright(c) 2024 Wind River Systems, Inc. */
+
+package networkAddressPools
+
+import "github.com/gophercloud/gophercloud"
+
+func resourceURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("network_addresspools", id)
+}
+
+func rootURL(c *gophercloud.ServiceClient) string {
+	return c.ServiceURL("network_addresspools")
+}
+
+func getURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}
+
+func listURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return resourceURL(c, id)
+}

--- a/starlingx/inventory/v1/networks/requests.go
+++ b/starlingx/inventory/v1/networks/requests.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2024 Wind River Systems, Inc. */
 
 package networks
 
@@ -19,11 +19,17 @@ const (
 	AllocationOrderStatic  = "static"
 )
 
+const (
+	IPv4Family = "ipv4"
+	IPv6Family = "ipv6"
+)
+
 type NetworkOpts struct {
 	Name     *string `json:"name,omitempty" mapstructure:"name"`
 	Type     *string `json:"type,omitempty" mapstructure:"type"`
 	Dynamic  *bool   `json:"dynamic,omitempty" mapstructure:"dynamic"`
 	PoolUUID *string `json:"pool_uuid,omitempty" mapstructure:"pool_uuid"`
+	// The 'primary_pool_family' is not a POSTable / PATCHable parameter.
 }
 
 // ListOptsBuilder allows extensions to add additional parameters to the

--- a/starlingx/inventory/v1/networks/results.go
+++ b/starlingx/inventory/v1/networks/results.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2024 Wind River Systems, Inc. */
 
 package networks
 
@@ -58,6 +58,10 @@ type Network struct {
 
 	// Pool UUID is a reference to the underlying address pool resource.
 	PoolUUID string `json:"pool_uuid"`
+
+	// PrimaryPoolFamily indicates whether the primary stack is of "ipv4" or "ipv6" family.
+	// The value can either be "ipv4" or "ipv6".
+	PrimaryPoolFamily string `json:"primary_pool_family"`
 
 	// CreatedAt defines the timestamp at which the resource was created.
 	CreatedAt string `json:"created_at"`

--- a/starlingx/inventory/v1/networks/testing/fixtures.go
+++ b/starlingx/inventory/v1/networks/testing/fixtures.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2024 Wind River Systems, Inc. */
 
 package testing
 
@@ -15,24 +15,26 @@ import (
 
 var (
 	NetworkHerp = networks.Network{
-		UUID:      "f30e3a13-addf-4a8e-8854-43c8e477d10d",
-		ID:        1,
-		Name:      "Herp",
-		Type:      "mgmt",
-		Dynamic:   true,
-		PoolUUID:  "5a74726d-5e8a-4396-8ae1-f19779fbcf4f",
-		CreatedAt: "",
-		UpdatedAt: nil,
+		UUID:              "f30e3a13-addf-4a8e-8854-43c8e477d10d",
+		ID:                1,
+		Name:              "Herp",
+		Type:              "mgmt",
+		PrimaryPoolFamily: networks.IPv6Family,
+		Dynamic:           true,
+		PoolUUID:          "5a74726d-5e8a-4396-8ae1-f19779fbcf4f",
+		CreatedAt:         "",
+		UpdatedAt:         nil,
 	}
 	NetworkDerp = networks.Network{
-		UUID:      "f757b5c7-89ab-4d93-bfd7-a97780ec2c1e",
-		ID:        2,
-		Name:      "Derp",
-		Type:      "oam",
-		Dynamic:   false,
-		PoolUUID:  "c7ac5a0c-606b-4fe0-9065-28a8c8fb78cc",
-		CreatedAt: "",
-		UpdatedAt: nil,
+		UUID:              "f757b5c7-89ab-4d93-bfd7-a97780ec2c1e",
+		ID:                2,
+		Name:              "Derp",
+		Type:              "oam",
+		PrimaryPoolFamily: networks.IPv4Family,
+		Dynamic:           false,
+		PoolUUID:          "c7ac5a0c-606b-4fe0-9065-28a8c8fb78cc",
+		CreatedAt:         "",
+		UpdatedAt:         nil,
 	}
 )
 
@@ -45,6 +47,7 @@ const NetworkListBody = `
           "name": "Herp",
           "pool_uuid": "5a74726d-5e8a-4396-8ae1-f19779fbcf4f",
           "type": "mgmt",
+          "primary_pool_family": "ipv6",
           "uuid": "f30e3a13-addf-4a8e-8854-43c8e477d10d"
         },
         {
@@ -53,6 +56,7 @@ const NetworkListBody = `
           "name": "Derp",
           "pool_uuid": "c7ac5a0c-606b-4fe0-9065-28a8c8fb78cc",
           "type": "oam",
+          "primary_pool_family": "ipv4",
           "uuid": "f757b5c7-89ab-4d93-bfd7-a97780ec2c1e"
         }
     ]
@@ -66,6 +70,7 @@ const SingleNetworkBody = `
     "name": "Derp",
     "pool_uuid": "c7ac5a0c-606b-4fe0-9065-28a8c8fb78cc",
     "type": "oam",
+    "primary_pool_family": "ipv4",
     "uuid": "f757b5c7-89ab-4d93-bfd7-a97780ec2c1e"
 }
 `


### PR DESCRIPTION
Dual-stack networking has introduced API changes to the current "networks" API along with the introduction of "network_addresspools" API. The "iextoam" API has been deprecated and reconfiguration of all of the platform networks will be handled by "networks" and the "network_addresspools" API only.

Accordingly, in this commit, we are making changes to the existing "networks" gophercloud API to support new attributes and creating a new "networkAddressPools" gophercloud API to talk to the sysinv's "network_addresspools" API.

Test Cases:
1. PASS - PrimaryPoolFamily is present in networks.Get return value.
2. PASS - PrimaryPoolFamily is present in all the network objects of networks.ListNetworks return value.
3. PASS - The "networkAddressPools" unit tests for List, Get, Create and ListNetworkAddressPools functions are executed successfully with correct fixtures.