### PR TITLE
Update of networkAddressPool API Attributes to Align with SysInv

### DIFF
--- a/starlingx/inventory/v1/networkAddressPools/requests.go
+++ b/starlingx/inventory/v1/networkAddressPools/requests.go
@@ -11,9 +11,9 @@ import (
 
 type NetworkAddressPoolOpts struct {
 	NetworkUUID     *string `json:"network_uuid,omitempty" mapstructure:"network_uuid"`
-	AddressPoolUUID *string `json:"addresspool_uuid,omitempty" mapstructure:"addresspool_uuid"`
+	AddressPoolUUID *string `json:"address_pool_uuid,omitempty" mapstructure:"address_pool_uuid"`
 	NetworkName     *string `json:"network_name,omitempty" mapstructure:"network_name"`
-	AddressPoolName *string `json:"addresspool_name,omitempty" mapstructure:"addresspool_name"`
+	AddressPoolName *string `json:"address_pool_name,omitempty" mapstructure:"address_pool_name"`
 }
 
 // ListOptsBuilder allows extensions to add additional parameters to the

--- a/starlingx/inventory/v1/networkAddressPools/results.go
+++ b/starlingx/inventory/v1/networkAddressPools/results.go
@@ -43,13 +43,13 @@ type NetworkAddressPool struct {
 	NetworkUUID string `json:"network_uuid"`
 
 	// AddressPoolUUID is the UUID of the address pool resource
-	AddressPoolUUID string `json:"addresspool_uuid"`
+	AddressPoolUUID string `json:"address_pool_uuid"`
 
 	// NetworkName is the name of network resource
 	NetworkName string `json:"network_name"`
 
 	// AddressPoolName is the name of the address pool resource
-	AddressPoolName string `json:"addresspool_name"`
+	AddressPoolName string `json:"address_pool_name"`
 }
 
 // NetworkAddressPool is the page returned by a pager when traversing over a

--- a/starlingx/inventory/v1/networkAddressPools/testing/fixtures.go
+++ b/starlingx/inventory/v1/networkAddressPools/testing/fixtures.go
@@ -37,16 +37,16 @@ const NetworkAddressPoolListBody = `
         {
 			"uuid": "11111111-a6e5-425e-9317-995da88d6694",
 			"network_uuid": "11111111-0000-425e-9317-995da88d6694",
-			"addresspool_uuid": "11111111-1111-425e-9317-995da88d6694",
+			"address_pool_uuid": "11111111-1111-425e-9317-995da88d6694",
 			"network_name": "oam",
-			"addresspool_name": "oam-ipv4"
+			"address_pool_name": "oam-ipv4"
 		},
 		{
 			"uuid": "22222222-a6e5-425e-9317-995da88d6694",
 			"network_uuid": "22222222-0000-425e-9317-995da88d6694",
-			"addresspool_uuid": "22222222-1111-425e-9317-995da88d6694",
+			"address_pool_uuid": "22222222-1111-425e-9317-995da88d6694",
 			"network_name": "oam",
-			"addresspool_name": "oam-ipv6"
+			"address_pool_name": "oam-ipv6"
 		}
     ]
 }
@@ -56,9 +56,9 @@ const SingleNetworkAddressPoolBody = `
 {
 	"uuid": "11111111-a6e5-425e-9317-995da88d6694",
 	"network_uuid": "11111111-0000-425e-9317-995da88d6694",
-	"addresspool_uuid": "11111111-1111-425e-9317-995da88d6694",
+	"address_pool_uuid": "11111111-1111-425e-9317-995da88d6694",
 	"network_name": "oam",
-	"addresspool_name": "oam-ipv4"
+	"address_pool_name": "oam-ipv4"
 }
 `
 
@@ -96,8 +96,8 @@ func HandleNetworkAddressPoolCreationSuccessfully(t *testing.T, response string)
 		th.TestJSONRequest(t, r, `{
           "network_uuid": "11111111-0000-425e-9317-995da88d6694",
           "network_name": "oam",
-          "addresspool_uuid": "11111111-1111-425e-9317-995da88d6694",
-          "addresspool_name": "oam-ipv4"
+          "address_pool_uuid": "11111111-1111-425e-9317-995da88d6694",
+          "address_pool_name": "oam-ipv4"
         }`)
 
 		w.WriteHeader(http.StatusAccepted)


### PR DESCRIPTION
We are updating "addresspool_uuid" to "address_pool_uuid" and "addresspool_name" to "address_pool_name" to align with latest network-addresspool API definition.

Test Cases:
1. PASS - Unit test cases are executed successfully.
2. PASS - Verify that network-addresspools can be successfully created / deleted with this change.