### PR TITLE
Fix ConvertPatchToMap for Nested Lists

### DIFF
--- a/starlingx/inventory/v1/addresspools/testing/fixtures.go
+++ b/starlingx/inventory/v1/addresspools/testing/fixtures.go
@@ -159,7 +159,7 @@ func HandleAddressPoolUpdateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestHeader(t, r, "Content-Type", "application/json")
-		th.TestJSONRequest(t, r, `[ { "op": "replace", "path": "/name", "value": "Changed" } ]`)
+		th.TestJSONRequest(t, r, `[ { "op": "replace", "path": "/name", "value": "Changed" }, {"op": "replace", "path": "/ranges", "value": [["169.254.202.1", "169.254.202.200"]]} ]`)
 
 		fmt.Fprintf(w, AddressPoolSingleBody)
 	})

--- a/starlingx/inventory/v1/addresspools/testing/requests_test.go
+++ b/starlingx/inventory/v1/addresspools/testing/requests_test.go
@@ -113,9 +113,10 @@ func TestUpdateAddressPool(t *testing.T) {
 	HandleAddressPoolUpdateSuccessfully(t)
 
 	name := "Changed"
+	ranges := [][]string{{"169.254.202.1", "169.254.202.200"}}
 	actual, err := addresspools.Update(client.ServiceClient(),
 		"123914e3-36e4-41a8-a702-d9f6e54d7140",
-		addresspools.AddressPoolOpts{Name: &name}).Extract()
+		addresspools.AddressPoolOpts{Name: &name, Ranges: &ranges}).Extract()
 	if err != nil {
 		t.Fatalf("Unexpected Update error: %v", err)
 	}

--- a/starlingx/patch.go
+++ b/starlingx/patch.go
@@ -57,6 +57,10 @@ func ConvertToPatchMap(obj interface{}, op PatchOp) ([]interface{}, error) {
 			if sliceValue.Len() > 0 && sliceValue.Index(0).Kind() == reflect.String {
 				// Convert slice of strings to comma-separated string
 				value = strings.Join(value.([]string), ",")
+			} else if sliceValue.Len() > 0 && sliceValue.Index(0).Kind() == reflect.Slice {
+				// "Ranges" in case of addresspool API is a nested list and system API
+				// supports nested list at least in this case.
+				value = result[k]
 			} else {
 				// The system API expects empty list as "none"
 				value = "none"


### PR DESCRIPTION
Fix ConvertPatchToMap for Nested Lists
In case of nested lists the ConvertPatchToMap incorrectly constructed
the patch request with value of "none" even when there were values.

Here, we are fixing this exact issue which was observed while updating
the range of the addresspool during OAM network reconfiguration.

Test Cases:
1. PASS - Verify that updated unit test cases are executed successfully.
2. PASS - Verify that range of the addresspool is updated successfully
          during OAM network reconfiguration
