### PR TITLE
Add create and delete routes for controllerfs

### DIFF
--- a/starlingx/inventory/v1/controllerFilesystems/requests.go
+++ b/starlingx/inventory/v1/controllerFilesystems/requests.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019-2023 Wind River Systems, Inc. */
+/* Copyright(c) 2019-2024 Wind River Systems, Inc. */
 
 package controllerFilesystems
 
@@ -122,4 +122,24 @@ func ListFileSystems(c *gophercloud.ServiceClient) ([]FileSystem, error) {
 	}
 
 	return objs, err
+}
+
+// Create accepts a CreateOpts struct and creates a new controller filesystem using the
+// values provided.
+func Create(client *gophercloud.ServiceClient, opts FileSystemOpts) (r CreateResult) {
+	reqBody, err := common.ConvertToCreateMap(opts)
+	if err != nil {
+		r.Err = err
+		return r
+	}
+	_, r.Err = client.Post(createURL(client), reqBody, &r.Body, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 201, 202},
+	})
+	return r
+}
+
+// Delete accepts a unique ID and deletes the controller filesystem associated with it.
+func Delete(c *gophercloud.ServiceClient, id string) (r DeleteResult) {
+	_, r.Err = c.Delete(deleteURL(c, id), nil)
+	return r
 }

--- a/starlingx/inventory/v1/controllerFilesystems/results.go
+++ b/starlingx/inventory/v1/controllerFilesystems/results.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019 Wind River Systems, Inc. */
+/* Copyright(c) 2019,2024 Wind River Systems, Inc. */
 
 package controllerFilesystems
 
@@ -26,6 +26,16 @@ type GetResult struct {
 
 // CreateResult represents the result of an update operation.
 type UpdateResult struct {
+	gophercloud.ErrResult
+}
+
+// CreateResult represents the result of an Create operation.
+type CreateResult struct {
+	commonResult
+}
+
+// DeleteResult contains the response body and error from a Delete request.
+type DeleteResult struct {
 	gophercloud.ErrResult
 }
 

--- a/starlingx/inventory/v1/controllerFilesystems/testing/fixtures.go
+++ b/starlingx/inventory/v1/controllerFilesystems/testing/fixtures.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019 Wind River Systems, Inc. */
+/* Copyright(c) 2019,2024 Wind River Systems, Inc. */
 
 package testing
 
@@ -142,6 +142,29 @@ const FileSystemSingleBody = `
       "uuid": "ff2e628d-23b2-4d73-b6b5-1c291ab6905a"
 }
 `
+const ControllerFSCephFloatSingleBody = `
+{
+      "created_at": "2024-07-12T15:41:10.295207+00:00",
+      "isystem_uuid": "52a7c2b0-ee64-4090-9d6e-c60892128a05",
+      "links": [
+        {
+          "href": "http://192.168.204.2:6385/v1/controller_fs/f3fb26d3-3ab8-416d-b360-ca25e630159d",
+          "rel": "self"
+        },
+        {
+          "href": "http://192.168.204.2:6385/controller_fs/f3fb26d3-3ab8-416d-b360-ca25e630159d",
+          "rel": "bookmark"
+        }
+      ],
+      "logical_volume": "ceph-float-lv",
+      "name": "ceph-float",
+      "replicated": false,
+      "size": 20,
+      "state": null,
+      "updated_at": null,
+      "uuid": "f3fb26d3-3ab8-416d-b360-ca25e630159d"
+}
+`
 
 func HandleFileSystemListSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/controller_fs", func(w http.ResponseWriter, r *http.Request) {
@@ -169,5 +192,29 @@ func HandleFileSystemUpdateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestJSONRequest(t, r, `[ { "op": "replace", "path": "/name", "value": "new-name" } ]`)
 		fmt.Fprintf(w, FileSystemSingleBody)
+	})
+}
+
+func HandleControllerFSCreationSuccessfully(t *testing.T, response string) {
+	th.Mux.HandleFunc("/controller_fs", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequest(t, r, `{
+			"name": "ceph-float",
+			"size": 20
+		}`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprint(w, response)
+	})
+}
+
+func HandleControllerFSDeletionSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/controller_fs/f3fb26d3-3ab8-416d-b360-ca25e630159d", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "DELETE")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+
+		w.WriteHeader(http.StatusNoContent)
 	})
 }

--- a/starlingx/inventory/v1/controllerFilesystems/testing/requests_test.go
+++ b/starlingx/inventory/v1/controllerFilesystems/testing/requests_test.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019 Wind River Systems, Inc. */
+/* Copyright(c) 2019,2024 Wind River Systems, Inc. */
 
 package testing
 
@@ -67,4 +67,32 @@ func TestGetFileSystem(t *testing.T) {
 	}
 
 	th.CheckDeepEquals(t, FileSystemDerp, *actual)
+}
+
+func TestCreateControllerFS(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleControllerFSCreationSuccessfully(t, ControllerFSCephFloatSingleBody)
+	name := "ceph-float"
+	size := 20
+	options := controllerFilesystems.FileSystemOpts{
+		Size: size,
+		Name: name,
+	}
+	actual, err := controllerFilesystems.Create(client.ServiceClient(), options).Extract()
+	th.AssertNoErr(t, err)
+
+	th.AssertEquals(t, actual.Size, 20)
+	th.AssertEquals(t, actual.Name, "ceph-float")
+}
+
+func TestDeleteControllerFS(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+
+	HandleControllerFSDeletionSuccessfully(t)
+
+	res := controllerFilesystems.Delete(client.ServiceClient(), "f3fb26d3-3ab8-416d-b360-ca25e630159d")
+	th.AssertNoErr(t, res.Err)
 }

--- a/starlingx/inventory/v1/controllerFilesystems/urls.go
+++ b/starlingx/inventory/v1/controllerFilesystems/urls.go
@@ -1,5 +1,5 @@
 /* SPDX-License-Identifier: Apache-2.0 */
-/* Copyright(c) 2019 Wind River Systems, Inc. */
+/* Copyright(c) 2019,2024 Wind River Systems, Inc. */
 
 package controllerFilesystems
 
@@ -23,4 +23,12 @@ func listURL(c *gophercloud.ServiceClient) string {
 
 func updateURL(c *gophercloud.ServiceClient, systemId string) string {
 	return c.ServiceURL("isystems", systemId, "controller_fs", "update_many")
+}
+
+func createURL(c *gophercloud.ServiceClient) string {
+	return rootURL(c)
+}
+
+func deleteURL(c *gophercloud.ServiceClient, id string) string {
+	return c.ServiceURL("controller_fs", id)
 }


### PR DESCRIPTION
Support for Create and Delete controller filesystem.

This pull request adds support for creating and deleting a controller filesystem.
Currently, only the creation of the controllerfs 'ceph-float' is allowed.
It is used to establish ceph-specific storage on controllers for Rook Ceph support.

Test Cases:

   1. PASS: Verify that controllerfs unit test cases are executed successfully.
   2. PASS: Using a DM custom build, deploy a duplex environment creating a new controllerfs.