### PR TITLE
DEV: Add DM support for new fields and parameters

### DIFF
--- a/starlingx/inventory/v1/addresspools/testing/requests_test.go
+++ b/starlingx/inventory/v1/addresspools/testing/requests_test.go
@@ -82,7 +82,7 @@ func TestCreateAddressPool(t *testing.T) {
 	floating_addr := "169.254.202.2"
 	c0_addr := "169.254.202.3"
 	c1_addr := "169.254.202.4"
-	
+
 	actual, err := addresspools.Create(client.ServiceClient(), addresspools.AddressPoolOpts{
 		Name:               &name,
 		Prefix:             &prefix,

--- a/starlingx/inventory/v1/osds/requests.go
+++ b/starlingx/inventory/v1/osds/requests.go
@@ -80,7 +80,8 @@ func Get(c *gophercloud.ServiceClient, id string) GetResult {
 // fixUnits is a utility method which converts the incoming size attributes
 // from GiB units to the system API MiB equivalent.
 // TODO(alegacy): remove once system API is converted to GiB units.
-//  See: https://bugs.launchpad.net/bugs/1823737
+//
+//	See: https://bugs.launchpad.net/bugs/1823737
 func (opts *OSDOpts) fixUnits() {
 	if opts.JournalSize != nil {
 		*opts.JournalSize = *opts.JournalSize * int(units.Kibibyte)

--- a/starlingx/inventory/v1/partitions/requests.go
+++ b/starlingx/inventory/v1/partitions/requests.go
@@ -100,7 +100,8 @@ func Get(c *gophercloud.ServiceClient, id string) GetResult {
 // fixUnits is a utility method which converts the incoming size attributes
 // from GiB units to the system API MiB equivalent.
 // TODO(alegacy): remove once system API is converted to GiB units.
-//  See: https://bugs.launchpad.net/bugs/1823737
+//
+//	See: https://bugs.launchpad.net/bugs/1823737
 func (opts *DiskPartitionOpts) fixUnits() {
 	opts.Size = opts.Size * int(units.Kibibyte) // GiB -> MiB
 }

--- a/starlingx/inventory/v1/ptpinstances/requests.go
+++ b/starlingx/inventory/v1/ptpinstances/requests.go
@@ -15,10 +15,9 @@ const (
 	ServiceTs2phc  = "ts2phc"
 )
 
-
 type PTPInstanceOpts struct {
-	Name	  *string `json:"name,omitempty" mapstructure:"name"`
-	Service   *string `json:"service,omitempty" mapstructure:"service"`
+	Name    *string `json:"name,omitempty" mapstructure:"name"`
+	Service *string `json:"service,omitempty" mapstructure:"service"`
 }
 
 // PATCH /v1/ptp_instances/{ptpinstance_uuid}
@@ -114,10 +113,10 @@ func Create(c *gophercloud.ServiceClient, opts PTPInstanceOpts) (r CreateResult)
 	return r
 }
 
-// AddPTPParamToPTPInst accepts a PatchOpts struct and updates an existing 
+// AddPTPParamToPTPInst accepts a PatchOpts struct and updates an existing
 // PTPInstance to associate with a PTP parameter
-func AddPTPParamToPTPInst(c *gophercloud.ServiceClient, id string, opts PTPParamToPTPInstOpts) (r UpdateResult) {
-	reqBody, err := common.ConvertToPatchMap(opts, common.AddOp)
+func AddPTPParamToPTPInst(c *gophercloud.ServiceClient, id string, section string, opts PTPParamToPTPInstOpts) (r UpdateResult) {
+	reqBody, err := common.ConvertToSectionalPatchMap(section, opts, common.AddOp)
 	if err != nil {
 		r.Err = err
 		return r
@@ -131,10 +130,10 @@ func AddPTPParamToPTPInst(c *gophercloud.ServiceClient, id string, opts PTPParam
 	return r
 }
 
-// RemovePTPParamFromPTPInst accepts a PatchOpts struct and updates an existing 
+// RemovePTPParamFromPTPInst accepts a PatchOpts struct and updates an existing
 // PTPInstance to remove a certain PTP parameter
-func RemovePTPParamFromPTPInst(c *gophercloud.ServiceClient, id string, opts PTPParamToPTPInstOpts) (r UpdateResult) {
-	reqBody, err := common.ConvertToPatchMap(opts, common.RemoveOp)
+func RemovePTPParamFromPTPInst(c *gophercloud.ServiceClient, id string, section string, opts PTPParamToPTPInstOpts) (r UpdateResult) {
+	reqBody, err := common.ConvertToSectionalPatchMap(section, opts, common.RemoveOp)
 	if err != nil {
 		r.Err = err
 		return r
@@ -210,7 +209,7 @@ func ListHostPTPInstances(c *gophercloud.ServiceClient, hostID string) ([]PTPIns
 	return objs, err
 }
 
-// AddPTPInstanceToHost accepts a PatchOpts struct and updates an existing 
+// AddPTPInstanceToHost accepts a PatchOpts struct and updates an existing
 // PTPInstance to associate with a host.
 func AddPTPInstanceToHost(c *gophercloud.ServiceClient, hostID string, opts PTPInstToHostOpts) (r UpdateResult) {
 	reqBody, err := common.ConvertToPatchMap(opts, common.AddOp)

--- a/starlingx/inventory/v1/ptpinstances/results.go
+++ b/starlingx/inventory/v1/ptpinstances/results.go
@@ -61,8 +61,8 @@ type PTPInstance struct {
 	// Hostnames is the list of the host names assigned to the ptp instance.
 	HostNames []string `json:"hostnames,omitempty"`
 
-	// Parameters is the list of the parameters assigned to the ptp instance.
-	Parameters []string `json:"parameters,omitempty"`
+	// Parameters is the list of the parameters grouped by section assigned to the ptp instance.
+	Parameters map[string][]string `json:"parameters,omitempty"`
 
 	// CreatedAt defines the timestamp at which the resource was created.
 	CreatedAt string `json:"created_at"`

--- a/starlingx/inventory/v1/ptpinstances/testing/fixtures.go
+++ b/starlingx/inventory/v1/ptpinstances/testing/fixtures.go
@@ -6,54 +6,54 @@ package testing
 import (
 	"fmt"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/ptpinstances"
+	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 	"net/http"
 	"testing"
-	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 var (
-	controllerHostID         = "daadd444-d2f5-464c-9527-96fd34a05c16"
-	herpUUID			     = "fa5defce-2546-4786-ae58-7bb08e2105fc"
-	PTPInstanceHerp 	     = ptpinstances.PTPInstance{
-		UUID: 	      herpUUID,
-		ID:           2,
-		Name:         "phc2sys1",
-		Service:      "phc2sys",
-		HostNames:    []string{},
-		Parameters:   []string{},
-		CreatedAt:    "2022-01-18T20:47:27.655974+00:00",
-		UpdatedAt:    nil,
+	controllerHostID = "daadd444-d2f5-464c-9527-96fd34a05c16"
+	herpUUID         = "fa5defce-2546-4786-ae58-7bb08e2105fc"
+	PTPInstanceHerp  = ptpinstances.PTPInstance{
+		UUID:       herpUUID,
+		ID:         2,
+		Name:       "phc2sys1",
+		Service:    "phc2sys",
+		HostNames:  []string{},
+		Parameters: map[string][]string{},
+		CreatedAt:  "2022-01-18T20:47:27.655974+00:00",
+		UpdatedAt:  nil,
 	}
-	PTPInstanceDerp 	     = ptpinstances.PTPInstance{
-		UUID:         "53041360-451f-49ea-8843-44fab16f6628",
-		ID:           1,
-		Name:         "ptp1",
-		Service:      "ptp4l",
-		HostNames:    []string{},
-		Parameters:   []string{},
-		CreatedAt:    "2022-01-18T17:56:43.012323+00:00",
-		UpdatedAt:    nil,
+	PTPInstanceDerp = ptpinstances.PTPInstance{
+		UUID:       "53041360-451f-49ea-8843-44fab16f6628",
+		ID:         1,
+		Name:       "ptp1",
+		Service:    "ptp4l",
+		HostNames:  []string{},
+		Parameters: map[string][]string{},
+		CreatedAt:  "2022-01-18T17:56:43.012323+00:00",
+		UpdatedAt:  nil,
 	}
-	PTPInstanceHerpUpdated   = ptpinstances.PTPInstance{
-		UUID: 	      herpUUID,
-		ID:           2,
-		Name:         "phc2sys1",
-		Service:      "phc2sys",
-		HostNames:    []string{},
-		Parameters:   []string{"domainNumber=24"},
-		CreatedAt:    "2022-01-18T20:47:27.655974+00:00",
-		UpdatedAt:    nil,
+	PTPInstanceHerpUpdated = ptpinstances.PTPInstance{
+		UUID:       herpUUID,
+		ID:         2,
+		Name:       "phc2sys1",
+		Service:    "phc2sys",
+		HostNames:  []string{},
+		Parameters: map[string][]string{"global": []string{"domainNumber=24"}},
+		CreatedAt:  "2022-01-18T20:47:27.655974+00:00",
+		UpdatedAt:  nil,
 	}
 	PTPInstanceHerpAddToHost = ptpinstances.PTPInstance{
-		UUID: 	      herpUUID,
-		ID:           2,
-		Name:         "phc2sys1",
-		Service:      "phc2sys",
-		HostNames:    []string{"controller-0"},
-		Parameters:   []string{},
-		CreatedAt:    "2022-01-18T20:47:27.655974+00:00",
-		UpdatedAt:    nil,
+		UUID:       herpUUID,
+		ID:         2,
+		Name:       "phc2sys1",
+		Service:    "phc2sys",
+		HostNames:  []string{"controller-0"},
+		Parameters: map[string][]string{},
+		CreatedAt:  "2022-01-18T20:47:27.655974+00:00",
+		UpdatedAt:  nil,
 	}
 )
 
@@ -67,7 +67,7 @@ const PTPInstanceListBody = `
 		 	"updated_at": null,
 		 	"capabilities": {},
 		 	"hostnames": [],
-		 	"parameters": [],
+			"parameters": {},
 		 	"type": "ptp-instance",
 		 	"id": 2,
 		 	"name": "phc2sys1"
@@ -79,7 +79,7 @@ const PTPInstanceListBody = `
 			"updated_at": null,
 			"capabilities": {},
 			"hostnames": [],
-			"parameters": [],
+			"parameters": {},
 			"type": "ptp-instance",
 			"id": 1,
 			"name": "ptp1"
@@ -96,7 +96,7 @@ const PTPInstanceSingleBody = `
 	"updated_at": null,
 	"capabilities": {},
 	"hostnames": [],
-	"parameters": [],
+	"parameters": {},
 	"type": "ptp-instance",
 	"id": 2,
 	"name": "phc2sys1"
@@ -111,7 +111,7 @@ const AddPTPParametersBody = `
 	"updated_at": null,
 	"capabilities": {},
 	"hostnames": [],
-	"parameters": ["domainNumber=24"],
+	"parameters": {"global": ["domainNumber=24"]},
 	"type": "ptp-instance",
 	"id": 2,
 	"name": "phc2sys1"
@@ -126,7 +126,7 @@ const HerpAddToHostBody = `
 	"updated_at": null,
 	"capabilities": {},
 	"hostnames": ["controller-0"],
-	"parameters": [],
+	"parameters": {},
 	"type": "ptp-instance",
 	"id": 2,
 	"name": "phc2sys1"
@@ -200,7 +200,7 @@ func HandleAddPTPParameterSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestHeader(t, r, "Content-Type", "application/json")
-		th.TestJSONRequest(t, r, `[ { "op": "add", "path": "/ptp_parameters/-", "value": "domainNumber=24" } ]`)
+		th.TestJSONRequest(t, r, `[ { "op": "add", "path": "/ptp_parameters/-", "section": "global", "value": "domainNumber=24" } ]`)
 		fmt.Fprintf(w, AddPTPParametersBody)
 	})
 }
@@ -211,7 +211,7 @@ func HandleRemovePTPParameterSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestHeader(t, r, "Content-Type", "application/json")
-		th.TestJSONRequest(t, r, `[ { "op": "remove", "path": "/ptp_parameters/-", "value": "domainNumber=24" } ]`)
+		th.TestJSONRequest(t, r, `[ { "op": "remove", "path": "/ptp_parameters/-", "section": "global", "value": "domainNumber=24" } ]`)
 		fmt.Fprintf(w, PTPInstanceSingleBody)
 	})
 }

--- a/starlingx/inventory/v1/ptpinstances/testing/requests_test.go
+++ b/starlingx/inventory/v1/ptpinstances/testing/requests_test.go
@@ -6,9 +6,9 @@ package testing
 import (
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/ptpinstances"
+	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 	"testing"
-	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 func TestListPTPInstances(t *testing.T) {
@@ -96,10 +96,12 @@ func TestAddPTPParameter(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleAddPTPParameterSuccessfully(t)
 
+	section := "global"
 	newValue := "domainNumber=24"
 
 	actual, err := ptpinstances.AddPTPParamToPTPInst(client.ServiceClient(),
 		herpUUID,
+		section,
 		ptpinstances.PTPParamToPTPInstOpts{
 			Parameter: &newValue,
 		}).Extract()
@@ -114,10 +116,12 @@ func TestRemovePTPParameter(t *testing.T) {
 	defer th.TeardownHTTP()
 	HandleRemovePTPParameterSuccessfully(t)
 
+	section := "global"
 	newValue := "domainNumber=24"
 
 	actual, err := ptpinstances.RemovePTPParamFromPTPInst(client.ServiceClient(),
 		herpUUID,
+		section,
 		ptpinstances.PTPParamToPTPInstOpts{
 			Parameter: &newValue,
 		}).Extract()
@@ -135,7 +139,7 @@ func TestAddToHost(t *testing.T) {
 	herbID := 2
 
 	actual, err := ptpinstances.AddPTPInstanceToHost(client.ServiceClient(),
-	    controllerHostID,
+		controllerHostID,
 		ptpinstances.PTPInstToHostOpts{
 			PTPInstanceID: &herbID,
 		}).Extract()
@@ -153,7 +157,7 @@ func TestRemoveFromHost(t *testing.T) {
 	herbID := 2
 
 	actual, err := ptpinstances.RemovePTPInstanceFromHost(client.ServiceClient(),
-	    controllerHostID,
+		controllerHostID,
 		ptpinstances.PTPInstToHostOpts{
 			PTPInstanceID: &herbID,
 		}).Extract()

--- a/starlingx/inventory/v1/ptpinterfaces/requests.go
+++ b/starlingx/inventory/v1/ptpinterfaces/requests.go
@@ -10,7 +10,7 @@ import (
 )
 
 type PTPInterfaceOpts struct {
-	Name		    *string `json:"name,omitempty" mapstructure:"name"`
+	Name            *string `json:"name,omitempty" mapstructure:"name"`
 	PTPInstanceUUID *string `json:"ptp_instance_uuid, omitempty" mapstructure:"ptp_instance_uuid,omitempty"`
 }
 
@@ -209,7 +209,6 @@ func AddPTPParamToPTPInt(c *gophercloud.ServiceClient, id string, opts PTPParamT
 
 	return r
 }
-
 
 // RemovePTPParamFromPTPInt accepts a PatchOpts struct and updates an existing PTPInterface
 // to remove a certain PTP parameter

--- a/starlingx/inventory/v1/ptpinterfaces/requests.go
+++ b/starlingx/inventory/v1/ptpinterfaces/requests.go
@@ -11,7 +11,7 @@ import (
 
 type PTPInterfaceOpts struct {
 	Name            *string `json:"name,omitempty" mapstructure:"name"`
-	PTPInstanceUUID *string `json:"ptp_instance_uuid, omitempty" mapstructure:"ptp_instance_uuid,omitempty"`
+	PTPInstanceUUID *string `json:"ptp_instance_uuid,omitempty" mapstructure:"ptp_instance_uuid,omitempty"`
 }
 
 // PATCH /v1/ptp_interfaces/{ptpinterface_uuid}

--- a/starlingx/inventory/v1/ptpinterfaces/testing/fixtures.go
+++ b/starlingx/inventory/v1/ptpinterfaces/testing/fixtures.go
@@ -6,17 +6,17 @@ package testing
 import (
 	"fmt"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/ptpinterfaces"
+	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 	"net/http"
 	"testing"
-	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 var (
-	controllerHostID        = "daadd444-d2f5-464c-9527-96fd34a05c16"
-	interfaceUUID           = "f75b7395-df5f-422d-a404-db24d3a07cea"
-	herpUUID                = "53041360-451f-49ea-8843-44fab16f6628"
-	PTPInterfaceHerp        = ptpinterfaces.PTPInterface{
+	controllerHostID = "daadd444-d2f5-464c-9527-96fd34a05c16"
+	interfaceUUID    = "f75b7395-df5f-422d-a404-db24d3a07cea"
+	herpUUID         = "53041360-451f-49ea-8843-44fab16f6628"
+	PTPInterfaceHerp = ptpinterfaces.PTPInterface{
 		PTPInstanceUUID: herpUUID,
 		InterfaceNames:  []string{},
 		UUID:            "b7d51ba0-35d7-4bab-9e27-a8b701587c54",
@@ -28,7 +28,7 @@ var (
 		UpdatedAt:       nil,
 		Name:            "ptpint1",
 	}
-	PTPInterfaceDerp        = ptpinterfaces.PTPInterface{
+	PTPInterfaceDerp = ptpinterfaces.PTPInterface{
 		PTPInstanceUUID: "fa5defce-2546-4786-ae58-7bb08e2105fc",
 		InterfaceNames:  []string{},
 		UUID:            "45f0e417-26be-4ef7-b9c4-7283611a9c20",

--- a/starlingx/inventory/v1/ptpinterfaces/testing/requests_test.go
+++ b/starlingx/inventory/v1/ptpinterfaces/testing/requests_test.go
@@ -6,9 +6,9 @@ package testing
 import (
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/ptpinterfaces"
+	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 	"testing"
-	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 func TestListPTPInterfaces(t *testing.T) {
@@ -73,7 +73,7 @@ func TestListInterfacePTPInterfaces(t *testing.T) {
 	HandleIntPTPInterfaceListSuccessfully(t)
 
 	allPages, err := ptpinterfaces.InterfaceList(client.ServiceClient(),
-	    interfaceUUID,
+		interfaceUUID,
 		ptpinterfaces.ListOpts{}).AllPages()
 	th.AssertNoErr(t, err)
 	actual, err := ptpinterfaces.ExtractPTPInterfaces(allPages)
@@ -90,7 +90,7 @@ func TestCreatePTPInterface(t *testing.T) {
 	ptpInterfaceName := "ptpint1"
 	ptpInstanceUUID := "53041360-451f-49ea-8843-44fab16f6628"
 	actual, err := ptpinterfaces.Create(client.ServiceClient(), ptpinterfaces.PTPInterfaceOpts{
-		Name:    		 &ptpInterfaceName,
+		Name:            &ptpInterfaceName,
 		PTPInstanceUUID: &ptpInstanceUUID,
 	}).Extract()
 	th.AssertNoErr(t, err)
@@ -165,7 +165,7 @@ func TestAddPTPIntToInt(t *testing.T) {
 	PTPinterfaceID := 3
 
 	actual, err := ptpinterfaces.AddPTPIntToInt(client.ServiceClient(),
-	    interfaceUUID,
+		interfaceUUID,
 		ptpinterfaces.PTPIntToIntOpt{
 			PTPinterfaceID: &PTPinterfaceID,
 		}).Extract()
@@ -183,7 +183,7 @@ func TestRemovePTPIntFromInt(t *testing.T) {
 	PTPinterfaceID := 3
 
 	actual, err := ptpinterfaces.RemovePTPIntFromInt(client.ServiceClient(),
-	    interfaceUUID,
+		interfaceUUID,
 		ptpinterfaces.PTPIntToIntOpt{
 			PTPinterfaceID: &PTPinterfaceID,
 		}).Extract()

--- a/starlingx/inventory/v1/ptpparameters/results.go
+++ b/starlingx/inventory/v1/ptpparameters/results.go
@@ -44,6 +44,9 @@ type PTPParameter struct {
 	// UUID is generated unique UUID for the ptp parameter.
 	UUID string `json:"uuid"`
 
+	// Section is the Sectional value of PTP parameter
+	Section string `json:"section"`
+
 	// Name is the key of the PTP parameter.
 	Name string `json:"name"`
 
@@ -85,4 +88,3 @@ func ExtractPTPParameters(r pagination.Page) ([]PTPParameter, error) {
 
 	return s.PTPParameter, err
 }
-

--- a/starlingx/inventory/v1/ptpparameters/testing/fixtures.go
+++ b/starlingx/inventory/v1/ptpparameters/testing/fixtures.go
@@ -38,7 +38,7 @@ const PTPParameterListBody = `
 	"ptp_parameters": [
 		{
 			"owners": ["424e80da-fdb0-4ddb-9f75-fa65d312d413"],
-		        "section": "global",
+			"section": "global",
 			"name": "domainNumber",
 			"created_at": "2022-01-24T21:15:17.290128+00:00",
 			"updated_at": null,
@@ -47,7 +47,7 @@ const PTPParameterListBody = `
 		}, 
 		{
 			"owners": ["82ef99c1-af38-432d-b5ac-ce6719ffc771"],
-		        "section": "global",
+			"section": "global",
 			"name": "masterOnly",
 			"created_at": "2022-01-24T21:50:27.567466+00:00",
 			"updated_at": null,
@@ -106,7 +106,7 @@ func HandlePTPParameterCreationSuccessfully(t *testing.T, response string) {
 		th.TestJSONRequest(t, r, `{
           "name": "masterOnly",
           "value": "0",
-	  "section": "global"
+          "section": "global"
         }`)
 
 		w.WriteHeader(http.StatusAccepted)

--- a/starlingx/inventory/v1/ptpparameters/testing/fixtures.go
+++ b/starlingx/inventory/v1/ptpparameters/testing/fixtures.go
@@ -6,26 +6,28 @@ package testing
 import (
 	"fmt"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/ptpparameters"
+	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 	"net/http"
 	"testing"
-	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 var (
 	PTPParameterHerp = ptpparameters.PTPParameter{
-		Owners: []string{"424e80da-fdb0-4ddb-9f75-fa65d312d413"},
-		Name: "domainNumber",
-		Value: "24",
-		UUID: "dd16b9c3-0fd2-491e-811d-df890a1524a1",
+		Owners:    []string{"424e80da-fdb0-4ddb-9f75-fa65d312d413"},
+		Section:   "global",
+		Name:      "domainNumber",
+		Value:     "24",
+		UUID:      "dd16b9c3-0fd2-491e-811d-df890a1524a1",
 		CreatedAt: "2022-01-24T21:15:17.290128+00:00",
 		UpdatedAt: nil,
 	}
 	PTPParameterDerp = ptpparameters.PTPParameter{
-		Owners: []string{"82ef99c1-af38-432d-b5ac-ce6719ffc771"},
-		Name: "masterOnly",
-		Value: "0",
-		UUID: "868e0ab8-2bc3-4d92-b736-de06bb8feb12",
+		Owners:    []string{"82ef99c1-af38-432d-b5ac-ce6719ffc771"},
+		Section:   "global",
+		Name:      "masterOnly",
+		Value:     "0",
+		UUID:      "868e0ab8-2bc3-4d92-b736-de06bb8feb12",
 		CreatedAt: "2022-01-24T21:50:27.567466+00:00",
 		UpdatedAt: nil,
 	}
@@ -36,6 +38,7 @@ const PTPParameterListBody = `
 	"ptp_parameters": [
 		{
 			"owners": ["424e80da-fdb0-4ddb-9f75-fa65d312d413"],
+		        "section": "global",
 			"name": "domainNumber",
 			"created_at": "2022-01-24T21:15:17.290128+00:00",
 			"updated_at": null,
@@ -44,6 +47,7 @@ const PTPParameterListBody = `
 		}, 
 		{
 			"owners": ["82ef99c1-af38-432d-b5ac-ce6719ffc771"],
+		        "section": "global",
 			"name": "masterOnly",
 			"created_at": "2022-01-24T21:50:27.567466+00:00",
 			"updated_at": null,
@@ -62,7 +66,8 @@ const PTPParameterSingleBody = `
 	"updated_at": null,
 	"value": "0",
 	"id": 2,
-	"name": "masterOnly"
+	"name": "masterOnly",
+	"section": "global"
 }
 `
 
@@ -100,7 +105,8 @@ func HandlePTPParameterCreationSuccessfully(t *testing.T, response string) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestJSONRequest(t, r, `{
           "name": "masterOnly",
-          "value": "0"
+          "value": "0",
+	  "section": "global"
         }`)
 
 		w.WriteHeader(http.StatusAccepted)

--- a/starlingx/inventory/v1/ptpparameters/testing/requests_test.go
+++ b/starlingx/inventory/v1/ptpparameters/testing/requests_test.go
@@ -6,9 +6,9 @@ package testing
 import (
 	"github.com/gophercloud/gophercloud/pagination"
 	"github.com/gophercloud/gophercloud/starlingx/inventory/v1/ptpparameters"
+	th "github.com/gophercloud/gophercloud/testhelper"
 	"github.com/gophercloud/gophercloud/testhelper/client"
 	"testing"
-	th "github.com/gophercloud/gophercloud/testhelper"
 )
 
 func TestListPTPParameters(t *testing.T) {

--- a/starlingx/inventory/v1/serviceparameters/testing/fixtures.go
+++ b/starlingx/inventory/v1/serviceparameters/testing/fixtures.go
@@ -236,8 +236,11 @@ func HandleServiceParameterGetSuccessfully(t *testing.T) {
 	})
 }
 
-/* This mock function returns the PATCH for the ServiceParameter for bbqUUID
-This example is ONLY changing the 'value' to 'disabled' */
+/*
+	This mock function returns the PATCH for the ServiceParameter for bbqUUID
+
+This example is ONLY changing the 'value' to 'disabled'
+*/
 func HandleServiceParameterUpdateSuccessfully(t *testing.T) {
 	th.Mux.HandleFunc("/service_parameter/"+bbqUUID, func(w http.ResponseWriter, r *http.Request) {
 		th.TestMethod(t, r, "PATCH")

--- a/starlingx/patch.go
+++ b/starlingx/patch.go
@@ -81,6 +81,17 @@ func ConvertToPatchMap(obj interface{}, op PatchOp) ([]interface{}, error) {
 	return m, nil
 }
 
+func ConvertToSectionalPatchMap(section string, opts interface{}, op PatchOp) ([]interface{}, error) {
+	patches, err := ConvertToPatchMap(opts, op)
+	if err != nil {
+		return nil, err
+	}
+	for i := range patches {
+		patches[i].(map[string]interface{})["section"] = section
+	}
+	return patches, nil
+}
+
 func ConvertToCreateMap(obj interface{}) (map[string]interface{}, error) {
 	result := make(map[string]interface{})
 	err := mapstructure.Decode(obj, &result)


### PR DESCRIPTION
Implement functionality for users to create entries for "unicast_master_table" in the ptp4l config.

PTP instance's parameters are now tied to section, to have sectional parameters. All existing parameters are tied to global section and new parameters can be added under new section. The following input format would be
changed, from ==>
kind: PtpInstance
Spec:
  Parameters:
  - domainNumber=44

To ==>
kind: PtpInstance
Spec:
  Parameters:
    global:
    - domainNumber=44 unicast_master_table_1:
    - table_id=1
    - UDPv4=1.2.3.4
    - UDPv4=2.3.4.5

This commit changes ptpinstance's parameters from []string to map[string][]string both as input and output, the section value is passed to api.

TEST PLAN:
PASS: "make && DEBUG=yes make docker-build" finish successfully
