### PR TITLE
Add support to LVM Function option in Capabilities

### DIFF
--- a/starlingx/inventory/v1/volumegroups/requests.go
+++ b/starlingx/inventory/v1/volumegroups/requests.go
@@ -14,6 +14,7 @@ var SystemDefinedVolumeGroups = []string{"cgts-vg"}
 type CapabilitiesOpts struct {
 	ConcurrentDiskOperations *int    `json:"concurrent_disk_operations,omitempty" mapstructure:"concurrent_disk_operations"`
 	LVMType                  *string `json:"lvm_type,omitempty" mapstructure:"lvm_type"`
+	LVMFunction              *string `json:"lvm_function,omitempty" mapstructure:"lvm_function"`
 }
 
 type VolumeGroupOpts struct {

--- a/starlingx/inventory/v1/volumegroups/results.go
+++ b/starlingx/inventory/v1/volumegroups/results.go
@@ -83,6 +83,7 @@ type LVMInfo struct {
 // this resource.
 type Capabilities struct {
 	LVMType                  *string `json:"lvm_type"`
+	LVMFunction              *string `json:"lvm_function"`
 	ConcurrentDiskOperations *int    `json:"concurrent_disk_operations"`
 }
 

--- a/starlingx/inventory/v1/volumegroups/testing/fixtures.go
+++ b/starlingx/inventory/v1/volumegroups/testing/fixtures.go
@@ -174,6 +174,7 @@ func HandleVolumeGroupUpdateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "Content-Type", "application/json")
 		th.TestJSONRequest(t, r, `[ { "path": "/capabilities", "value": {
               "concurrent_disk_operations": null,
+			  "lvm_function": null,
               "lvm_type": null
             }, "op": "replace"} ]`)
 


### PR DESCRIPTION
This change aims to add support to the new capability [1] option for LVM Function in the host inventory. This is a result of the work to supports LVM as a storage backend in the system.

The new capability option will be used to categorize the volume group as lvm dedicated VG, allowing the system to detect and use it for storage purposes.

TEST PLAN:
PASS: Successfully executed the request to a new VG with 'lvm-csi'
      function.
PASS: Successfully configured new VG with 'lvm-csi' function. PASS: Successfully rejects VG with LVMType and no LVMFunction. PASS: 'go vet ./... && go test ./...'

[1] https://review.opendev.org/c/starlingx/config/+/968641
