### PR TITLE
Add support to Volume Group capabilities update

### DIFF
--- a/starlingx/inventory/v1/volumegroups/requests.go
+++ b/starlingx/inventory/v1/volumegroups/requests.go
@@ -4,6 +4,8 @@
 package volumegroups
 
 import (
+	"encoding/json"
+
 	"github.com/gophercloud/gophercloud"
 	"github.com/gophercloud/gophercloud/pagination"
 	common "github.com/gophercloud/gophercloud/starlingx"
@@ -15,6 +17,7 @@ type CapabilitiesOpts struct {
 	ConcurrentDiskOperations *int    `json:"concurrent_disk_operations,omitempty" mapstructure:"concurrent_disk_operations"`
 	LVMType                  *string `json:"lvm_type,omitempty" mapstructure:"lvm_type"`
 	LVMFunction              *string `json:"lvm_function,omitempty" mapstructure:"lvm_function"`
+	LVMPoolSize              *int    `json:"lvm_pool_size,omitempty" mapstructure:"lvm_pool_size"`
 }
 
 type VolumeGroupOpts struct {
@@ -93,10 +96,27 @@ func Create(c *gophercloud.ServiceClient, opts VolumeGroupOpts) (r CreateResult)
 // Update accepts a PatchOpts struct and updates an existing volume group using
 // the values provided. For more information, see the Create function.
 func Update(c *gophercloud.ServiceClient, id string, opts VolumeGroupOpts) (r UpdateResult) {
+	capOpts := opts.Capabilities
+	opts.Capabilities = nil
+
 	reqBody, err := common.ConvertToPatchMap(opts, common.ReplaceOp)
 	if err != nil {
 		r.Err = err
 		return r
+	}
+
+	if capOpts != nil {
+		capJSON, err := json.Marshal(capOpts)
+		if err != nil {
+			r.Err = err
+			return r
+		}
+
+		reqBody = append(reqBody, map[string]interface{}{
+			"op":    common.ReplaceOp,
+			"path":  "/capabilities",
+			"value": string(capJSON),
+		})
 	}
 
 	// Send request to API

--- a/starlingx/inventory/v1/volumegroups/results.go
+++ b/starlingx/inventory/v1/volumegroups/results.go
@@ -84,6 +84,7 @@ type LVMInfo struct {
 type Capabilities struct {
 	LVMType                  *string `json:"lvm_type"`
 	LVMFunction              *string `json:"lvm_function"`
+	LVMPoolSize              *int    `json:"lvm_pool_size"`
 	ConcurrentDiskOperations *int    `json:"concurrent_disk_operations"`
 }
 

--- a/starlingx/inventory/v1/volumegroups/testing/fixtures.go
+++ b/starlingx/inventory/v1/volumegroups/testing/fixtures.go
@@ -172,12 +172,67 @@ func HandleVolumeGroupUpdateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestHeader(t, r, "Content-Type", "application/json")
-		th.TestJSONRequest(t, r, `[ { "path": "/capabilities", "value": {
-              "concurrent_disk_operations": null,
-			  "lvm_function": null,
-              "lvm_type": null
-            }, "op": "replace"} ]`)
+		th.TestJSONRequest(t, r, `[ { "path": "/capabilities", "value": "{}", "op": "replace"} ]`)
 
 		fmt.Fprint(w, VolumeGroupSingleBody)
+	})
+}
+
+var (
+	LVMFunctionCSI            = "lvm-csi"
+	VolumeGroupUpdatedBody    = `
+{
+	"lvm_vg_access": "wz--n-",
+	"lvm_vg_size": 36503027712,
+	"lvm_max_lv": 0,
+	"lvm_vg_free_pe": 0,
+	"uuid": "449aee64-342f-4255-9a23-b229b0589c1b",
+	"lvm_cur_lv": 1,
+	"created_at": "2019-11-07T21:07:46.112632+00:00",
+	"lvm_max_pv": 0,
+	"updated_at": "2019-11-14T21:04:50.029120+00:00",
+	"capabilities": {"lvm_function": "lvm-csi"},
+	"vg_state": "provisioned",
+	"lvm_vg_avail_size": 0,
+	"ihost_uuid": "f757b5c7-89ab-4d93-bfd7-a97780ec2c1e",
+	"lvm_cur_pv": 1,
+	"lvm_vg_uuid": "VI0rH6-sFJr-SaGV-QfmU-ogMu-UKMa-g45SjM",
+	"lvm_vg_total_pe": 8703,
+	"lvm_vg_name": "lvm-provisioner"
+}
+`
+	VolumeGroupDerpUpdated = volumegroups.VolumeGroup{
+		ID:     "449aee64-342f-4255-9a23-b229b0589c1b",
+		HostID: "f757b5c7-89ab-4d93-bfd7-a97780ec2c1e",
+		State:  "provisioned",
+		Capabilities: volumegroups.Capabilities{
+			LVMFunction: &LVMFunctionCSI,
+		},
+		LVMInfo: volumegroups.LVMInfo{
+			Name:                   "lvm-provisioner",
+			GroupUUID:              "VI0rH6-sFJr-SaGV-QfmU-ogMu-UKMa-g45SjM",
+			Access:                 "wz--n-",
+			Size:                   36503027712,
+			AvailableSize:          0,
+			TotalPE:                8703,
+			FreePE:                 0,
+			CurrentLogicalVolumes:  1,
+			CurrentPhysicalVolumes: 1,
+			MaximumPhysicalVolumes: 0,
+		},
+		CreatedAt: "2019-11-07T21:07:46.112632+00:00",
+		UpdatedAt: &UpdatedAtDerp,
+	}
+)
+
+func HandleVolumeGroupUpdateCapabilitiesSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/ilvgs/449aee64-342f-4255-9a23-b229b0589c1b", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequest(t, r, `[ { "path": "/capabilities", "value": "{\"lvm_function\":\"lvm-csi\"}", "op": "replace"} ]`)
+
+		fmt.Fprint(w, VolumeGroupUpdatedBody)
 	})
 }

--- a/starlingx/inventory/v1/volumegroups/testing/requests_test.go
+++ b/starlingx/inventory/v1/volumegroups/testing/requests_test.go
@@ -110,3 +110,22 @@ func TestUpdateVolumeGroup(t *testing.T) {
 	}
 	th.CheckDeepEquals(t, VolumeGroupDerp, *actual)
 }
+
+func TestUpdateVolumeGroupCapabilities(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleVolumeGroupUpdateCapabilitiesSuccessfully(t)
+
+	lvmFunction := "lvm-csi"
+	Capabilities := volumegroups.CapabilitiesOpts{
+		LVMFunction: &lvmFunction,
+	}
+	actual, err := volumegroups.Update(client.ServiceClient(),
+		"449aee64-342f-4255-9a23-b229b0589c1b",
+		volumegroups.VolumeGroupOpts{
+			Capabilities: &Capabilities}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update error: %v", err)
+	}
+	th.CheckDeepEquals(t, VolumeGroupDerpUpdated, *actual)
+}


### PR DESCRIPTION
This code change aims to add support for volume group (VG) capabilities update by equating the patch strategy with that applied by the lvg controller of sysinv [1]. This operation allow, i.e. the capabilities removal, addition or updating.

Also, the lvmPoolSize option is added to the LVG capabilities. Tests were updated to reflect the new implementation.

TEST PLAN:
PASS: Successfully executed the request to update a VG with new
      capabilities.
PASS: Successfully remove one or more capabilities from a VG. PASS: Successfully added and removed VGs from the system. PASS: 'go vet ./... && go test ./...'

[1] https://opendev.org/starlingx/config/src/commit/b7d7a9ca8758446244a1a8725b269c1288e6f6b0/sysinv/sysinv/sysinv/sysinv/api/controllers/v1/lvg.py#L331