### PR TITLE
Fix service parameter Apply to handle empty response body

### DIFF
--- a/starlingx/inventory/v1/serviceparameters/requests.go
+++ b/starlingx/inventory/v1/serviceparameters/requests.go
@@ -107,8 +107,8 @@ func Apply(c *gophercloud.ServiceClient, opts ServiceApplyOpts) (r ApplyResult) 
 		r.Err = err
 		return r
 	}
-	_, r.Err = c.Post(applyURL(c), reqBody, &r.Body, &gophercloud.RequestOpts{
-		OkCodes: []int{204},
+	_, r.Err = c.Post(applyURL(c), reqBody, nil, &gophercloud.RequestOpts{
+		OkCodes: []int{200, 204},
 	})
 	return r
 }


### PR DESCRIPTION
The service-parameter-apply API (POST /v1/service_parameter/apply) returns HTTP 200 with no JSON body. The Apply function was attempting to decode the response into r.Body, causing an EOF error.

Fix by passing nil as the response body pointer and accepting both 200 and 204 status codes.

Test Plan:
```
- PASS: successfully executed the request to apply a service parameter
- PASS: go vet ./... && go test ./...
```