### PR TITLE
Add ovs_access field to Interface and InterfaceOpts

### DIFF
--- a/starlingx/inventory/v1/addresspools/testing/fixtures.go
+++ b/starlingx/inventory/v1/addresspools/testing/fixtures.go
@@ -159,7 +159,7 @@ func HandleAddressPoolUpdateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestHeader(t, r, "Content-Type", "application/json")
-		th.TestJSONRequest(t, r, `[ { "op": "replace", "path": "/name", "value": "Changed" }, {"op": "replace", "path": "/ranges", "value": [["169.254.202.1", "169.254.202.200"]]} ]`)
+		th.TestJSONRequestUnordered(t, r, `[ {"op": "replace", "path": "/ranges", "value": [["169.254.202.1", "169.254.202.200"]]}, { "op": "replace", "path": "/name", "value": "Changed" } ]`)
 
 		fmt.Fprintf(w, AddressPoolSingleBody)
 	})

--- a/starlingx/inventory/v1/hostFilesystems/testing/fixtures.go
+++ b/starlingx/inventory/v1/hostFilesystems/testing/fixtures.go
@@ -126,7 +126,7 @@ func HandleFileSystemUpdateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestHeader(t, r, "Content-Type", "application/json")
-		th.TestJSONRequest(t, r, `[ [ { "op": "replace", "path": "/name", "value": "Derp"  }, { "op": "replace", "path": "/size", "value": 50 } ] ]`)
+		th.TestJSONRequestUnordered(t, r, `[ [ { "op": "replace", "path": "/size", "value": 50 }, { "op": "replace", "path": "/name", "value": "Derp" } ] ]`)
 		fmt.Fprint(w, FileSystemSingleBody)
 	})
 }

--- a/starlingx/inventory/v1/interfaces/requests.go
+++ b/starlingx/inventory/v1/interfaces/requests.go
@@ -77,6 +77,7 @@ type InterfaceOpts struct {
 	PTPRole          *string   `json:"ptp_role,omitempty" mapstructure:"ptp_role"`
 	MaxTxRate        *int      `json:"max_tx_rate,omitempty" mapstructure:"max_tx_rate"`
 	MaxRxRate        *int      `json:"max_rx_rate,omitempty" mapstructure:"max_rx_rate"`
+	OVSAccess        *bool     `json:"ovs_access,omitempty" mapstructure:"ovs_access"`
 }
 
 // ListOptsBuilder allows extensions to add additional parameters to the

--- a/starlingx/inventory/v1/interfaces/results.go
+++ b/starlingx/inventory/v1/interfaces/results.go
@@ -119,6 +119,9 @@ type Interface struct {
 
 	// max_rx_rate for rx rate limit configuration.
 	MaxRxRate int `json:"max_rx_rate"`
+
+	// OVSAccess indicates whether OVS access is enabled for this interface.
+	OVSAccess *bool `json:"ovs_access,omitempty"`
 }
 
 // InterfacePage is the page returned by a pager when traversing over a

--- a/starlingx/inventory/v1/interfaces/testing/fixtures.go
+++ b/starlingx/inventory/v1/interfaces/testing/fixtures.go
@@ -435,3 +435,82 @@ func HandlePlatformInterfaceCreationSuccessfully(t *testing.T, response string) 
 		fmt.Fprintf(w, response)
 	})
 }
+
+const OVSAccessInterfaceSingleBody = `
+{
+  "aemode": null,
+  "forihostid": 2,
+  "ifclass": "platform",
+  "ifname": "ovs0",
+  "iftype": "ethernet",
+  "ihost_uuid": "f73dda8e-be3c-4704-ad1e-ed99e44b846e",
+  "imac": "08:00:27:25:6a:20",
+  "imtu": 9000,
+  "ipv4_mode": "disabled",
+  "ipv6_mode": "disabled",
+  "sriov_numvfs": 0,
+  "sriov_vf_driver": null,
+  "txhashpolicy": null,
+  "used_by": [],
+  "uses": ["sriov0"],
+  "uuid": "c1e2d3f4-a5b6-7890-abcd-ef1234567890",
+  "vlan_id": null,
+  "ptp_role": "none",
+  "ovs_access": true
+}
+`
+
+var (
+	ovsAccessTrue            = true
+	ipv4ModeDisabled         = interfaces.AddressModeDisabled
+	ipv6ModeDisabled         = interfaces.AddressModeDisabled
+	ptpRoleNone              = interfaces.PTPRoleNone
+	vfCountZero              = 0
+	OVSAccessInterfaceExpected = interfaces.Interface{
+		ID:           "c1e2d3f4-a5b6-7890-abcd-ef1234567890",
+		Name:         "ovs0",
+		Type:         interfaces.IFTypeEthernet,
+		Class:        interfaces.IFClassPlatform,
+		MTU:          9000,
+		IPv4Mode:     &ipv4ModeDisabled,
+		IPv6Mode:     &ipv6ModeDisabled,
+		VFCount:      &vfCountZero,
+		Uses:         []string{"sriov0"},
+		Users:        []string{},
+		PTPRole:      &ptpRoleNone,
+		OVSAccess:    &ovsAccessTrue,
+	}
+)
+
+func HandleOVSAccessInterfaceCreationSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/iinterfaces", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequestUnordered(t, r, `{
+          "ifclass": "platform",
+          "ifname": "ovs0",
+          "iftype": "ethernet",
+          "ihost_uuid": "f73dda8e-be3c-4704-ad1e-ed99e44b846e",
+          "imtu": 9000,
+          "uses": ["sriov0"],
+          "usesmodify": [],
+          "ptp_role": "none",
+          "ovs_access": true
+        }`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, OVSAccessInterfaceSingleBody)
+	})
+}
+
+func HandleOVSAccessInterfaceUpdateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/iinterfaces/c1e2d3f4-a5b6-7890-abcd-ef1234567890", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequestUnordered(t, r, `[ { "op": "replace", "path": "/ovs_access", "value": true } ]`)
+		fmt.Fprintf(w, OVSAccessInterfaceSingleBody)
+	})
+}

--- a/starlingx/inventory/v1/interfaces/testing/requests_test.go
+++ b/starlingx/inventory/v1/interfaces/testing/requests_test.go
@@ -187,3 +187,49 @@ func TestDeleteInterface(t *testing.T) {
 	res := interfaces.Delete(client.ServiceClient(), "a5965fee-dc60-40dc-a234-edf87f1f9380")
 	th.AssertNoErr(t, res.Err)
 }
+
+func TestCreateOVSAccessInterface(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleOVSAccessInterfaceCreationSuccessfully(t)
+
+	interfaceHostID := "f73dda8e-be3c-4704-ad1e-ed99e44b846e"
+	interfaceName := "ovs0"
+	interfaceType := interfaces.IFTypeEthernet
+	interfaceClass := interfaces.IFClassPlatform
+	interfaceMTU := 9000
+	interfaceUses := []string{"sriov0"}
+	interfaceUsers := []string{}
+	ptpRole := interfaces.PTPRoleNone
+	ovsAccess := true
+
+	actual, err := interfaces.Create(client.ServiceClient(), interfaces.InterfaceOpts{
+		HostUUID:   &interfaceHostID,
+		Type:       &interfaceType,
+		Name:       &interfaceName,
+		Class:      &interfaceClass,
+		MTU:        &interfaceMTU,
+		Uses:       &interfaceUses,
+		UsesModify: &interfaceUsers,
+		PTPRole:    &ptpRole,
+		OVSAccess:  &ovsAccess,
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, OVSAccessInterfaceExpected, *actual)
+}
+
+func TestUpdateOVSAccessInterface(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleOVSAccessInterfaceUpdateSuccessfully(t)
+
+	ovsAccess := true
+	actual, err := interfaces.Update(client.ServiceClient(),
+		"c1e2d3f4-a5b6-7890-abcd-ef1234567890",
+		interfaces.InterfaceOpts{OVSAccess: &ovsAccess}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update error: %v", err)
+	}
+	th.CheckDeepEquals(t, OVSAccessInterfaceExpected, *actual)
+}

--- a/starlingx/inventory/v1/partitions/testing/fixtures.go
+++ b/starlingx/inventory/v1/partitions/testing/fixtures.go
@@ -155,7 +155,7 @@ func HandleDiskPartitionUpdateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestHeader(t, r, "Content-Type", "application/json")
-		th.TestJSONRequest(t, r, `[
+		th.TestJSONRequestUnordered(t, r, `[
           {
             "op": "replace",
             "path": "/ihost_uuid",

--- a/starlingx/inventory/v1/storagebackends/testing/fixtures.go
+++ b/starlingx/inventory/v1/storagebackends/testing/fixtures.go
@@ -139,7 +139,7 @@ func HandleStorageBackendUpdateSuccessfully(t *testing.T) {
 		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
 		th.TestHeader(t, r, "Accept", "application/json")
 		th.TestHeader(t, r, "Content-Type", "application/json")
-		th.TestJSONRequest(t, r, `[
+		th.TestJSONRequestUnordered(t, r, `[
 			{"path": "/capabilities", "value": {}, "op": "replace"},
 			{"op": "replace", "path": "/confirmed", "value": false}
 		]`)

--- a/testhelper/convenience.go
+++ b/testhelper/convenience.go
@@ -7,6 +7,7 @@ import (
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"sort"
 	"strings"
 	"testing"
 	"github.com/google/go-cmp/cmp"
@@ -328,7 +329,18 @@ func isJSONEqualsUnordered(t *testing.T, expectedJSON string, actual interface{}
 	err = json.Unmarshal(jsonActual, &parsedActual)
 	AssertNoErr(t, err)
 
-	if !cmp.Equal(parsedExpected, parsedActual) {
+	sortOpt := cmp.Transformer("SortSlices", func(in []interface{}) []interface{} {
+		out := make([]interface{}, len(in))
+		copy(out, in)
+		sort.Slice(out, func(i, j int) bool {
+			a, _ := json.Marshal(out[i])
+			b, _ := json.Marshal(out[j])
+			return string(a) < string(b)
+		})
+		return out
+	})
+
+	if !cmp.Equal(parsedExpected, parsedActual, sortOpt) {
 		prettyExpected, err := json.MarshalIndent(parsedExpected, "", "  ")
 		if err != nil {
 			t.Logf("Unable to pretty-print expected JSON: %v\n%s", err, expectedJSON)

--- a/testhelper/http_responses.go
+++ b/testhelper/http_responses.go
@@ -94,6 +94,24 @@ func TestJSONRequest(t *testing.T, r *http.Request, expected string) {
 	CheckJSONEquals(t, expected, actualJSON)
 }
 
+// TestJSONRequestUnordered verifies that the JSON request body matches
+// the expected value without considering the order of array elements or
+// object keys.
+func TestJSONRequestUnordered(t *testing.T, r *http.Request, expected string) {
+	b, err := ioutil.ReadAll(r.Body)
+	if err != nil {
+		t.Errorf("Unable to read request body: %v", err)
+	}
+
+	var actualJSON interface{}
+	err = json.Unmarshal(b, &actualJSON)
+	if err != nil {
+		t.Errorf("Unable to parse request body as JSON: %v", err)
+	}
+
+	CheckJSONEqualsUnordered(t, expected, actualJSON)
+}
+
 func normalizeMultipartBoundary(body string) string {
 	re := regexp.MustCompile(`^--[a-z0-9]{60}`)
 	boundary := re.FindString(body)


### PR DESCRIPTION
Add the ovs_access boolean field to the Interface struct for reading the OVS access state from the sysinv API, and to InterfaceOpts for setting it during interface create and update operations.

This supports configuring OVS access on ethernet interfaces that are created on top of pci-sriov lower interfaces.

Test Plan:
```
- PASS: successfully executed the request
- PASS: go vet ./... && go test ./.. --count=1
```