### PR TITLE
Add pfchannels and vfchannels to Interface and InterfaceOpts

### DIFF
--- a/starlingx/inventory/v1/interfaces/requests.go
+++ b/starlingx/inventory/v1/interfaces/requests.go
@@ -77,6 +77,8 @@ type InterfaceOpts struct {
 	PTPRole          *string   `json:"ptp_role,omitempty" mapstructure:"ptp_role"`
 	MaxTxRate        *int      `json:"max_tx_rate,omitempty" mapstructure:"max_tx_rate"`
 	MaxRxRate        *int      `json:"max_rx_rate,omitempty" mapstructure:"max_rx_rate"`
+	PFChannels       *int      `json:"channels,omitempty" mapstructure:"channels"`
+	VFChannels       *int      `json:"sriov_vf_channels,omitempty" mapstructure:"sriov_vf_channels"`
 	OVSAccess        *bool     `json:"ovs_access,omitempty" mapstructure:"ovs_access"`
 }
 

--- a/starlingx/inventory/v1/interfaces/results.go
+++ b/starlingx/inventory/v1/interfaces/results.go
@@ -120,6 +120,15 @@ type Interface struct {
 	// max_rx_rate for rx rate limit configuration.
 	MaxRxRate int `json:"max_rx_rate"`
 
+	// Channels defines the number of NIC channels (queues) configured on
+	// the interface. Only applicable if iftype is ethernet or ae.
+	PFChannels *int `json:"channels,omitempty"`
+
+	// SriovVFChannels defines the number of SR-IOV VF channels (queues)
+	// configured on the interface. Only applicable if ifclass is pci-sriov
+	// with sriov_vf_driver netdevice, or iftype vf.
+	VFChannels *int `json:"sriov_vf_channels,omitempty"`
+
 	// OVSAccess indicates whether OVS access is enabled for this interface.
 	OVSAccess *bool `json:"ovs_access,omitempty"`
 }

--- a/starlingx/inventory/v1/interfaces/testing/fixtures.go
+++ b/starlingx/inventory/v1/interfaces/testing/fixtures.go
@@ -514,3 +514,150 @@ func HandleOVSAccessInterfaceUpdateSuccessfully(t *testing.T) {
 		fmt.Fprintf(w, OVSAccessInterfaceSingleBody)
 	})
 }
+
+const ChannelsInterfaceSingleBody = `
+{
+  "aemode": null,
+  "forihostid": 2,
+  "ifclass": "platform",
+  "ifname": "pxeboot0",
+  "iftype": "ethernet",
+  "ihost_uuid": "f73dda8e-be3c-4704-ad1e-ed99e44b846e",
+  "imac": "08:00:27:25:6a:20",
+  "imtu": 9000,
+  "ipv4_mode": "static",
+  "ipv6_mode": "disabled",
+  "sriov_numvfs": 0,
+  "sriov_vf_driver": null,
+  "txhashpolicy": null,
+  "used_by": [],
+  "uses": [],
+  "uuid": "d1e2f3a4-b5c6-7890-abcd-ef1234567890",
+  "vlan_id": null,
+  "ptp_role": "none",
+  "channels": 8,
+  "sriov_vf_channels": null,
+  "max_tx_rate": 0,
+  "max_rx_rate": 0
+}
+`
+
+const VFChannelsInterfaceSingleBody = `
+{
+  "aemode": null,
+  "forihostid": 2,
+  "ifclass": "pci-sriov",
+  "ifname": "sriov-netdev0",
+  "iftype": "vf",
+  "ihost_uuid": "f73dda8e-be3c-4704-ad1e-ed99e44b846e",
+  "imac": "08:00:27:25:6a:20",
+  "imtu": 1500,
+  "ipv4_mode": "disabled",
+  "ipv6_mode": "disabled",
+  "sriov_numvfs": 4,
+  "sriov_vf_driver": "netdevice",
+  "txhashpolicy": null,
+  "used_by": [],
+  "uses": ["sriov0"],
+  "uuid": "e2f3a4b5-c6d7-8901-abcd-ef2345678901",
+  "vlan_id": null,
+  "ptp_role": "none",
+  "channels": null,
+  "sriov_vf_channels": 4,
+  "max_tx_rate": 0,
+  "max_rx_rate": 0
+}
+`
+
+var (
+	channelsValue          = 8
+	vfChannelsValue        = 4
+	vfCountFour            = 4
+	vfDriverNetdevice      = "netdevice"
+	ChannelsInterfaceExpected = interfaces.Interface{
+		ID:         "d1e2f3a4-b5c6-7890-abcd-ef1234567890",
+		Name:       "pxeboot0",
+		Type:       interfaces.IFTypeEthernet,
+		Class:      interfaces.IFClassPlatform,
+		MTU:        9000,
+		IPv4Mode:   &IPv4Modes[0],
+		IPv6Mode:   &ipv6ModeDisabled,
+		VFCount:    &vfCountZero,
+		Uses:       []string{},
+		Users:      []string{},
+		PTPRole:    &ptpRoleNone,
+		PFChannels: &channelsValue,
+	}
+	VFChannelsInterfaceExpected = interfaces.Interface{
+		ID:         "e2f3a4b5-c6d7-8901-abcd-ef2345678901",
+		Name:       "sriov-netdev0",
+		Type:       interfaces.IFTypeVF,
+		Class:      interfaces.IFClassPCISRIOV,
+		MTU:        1500,
+		IPv4Mode:   &ipv4ModeDisabled,
+		IPv6Mode:   &ipv6ModeDisabled,
+		VFCount:    &vfCountFour,
+		VFDriver:   &vfDriverNetdevice,
+		Uses:       []string{"sriov0"},
+		Users:      []string{},
+		PTPRole:    &ptpRoleNone,
+		VFChannels: &vfChannelsValue,
+	}
+)
+
+func HandleChannelsInterfaceCreationSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/iinterfaces", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequestUnordered(t, r, `{
+          "ifclass": "platform",
+          "ifname": "pxeboot0",
+          "iftype": "ethernet",
+          "ihost_uuid": "f73dda8e-be3c-4704-ad1e-ed99e44b846e",
+          "imtu": 9000,
+          "channels": 8,
+          "uses": [],
+          "usesmodify": [],
+          "ptp_role": "none"
+        }`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, ChannelsInterfaceSingleBody)
+	})
+}
+
+func HandleVFChannelsInterfaceCreationSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/iinterfaces", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "POST")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestJSONRequestUnordered(t, r, `{
+          "ifclass": "pci-sriov",
+          "ifname": "sriov-netdev0",
+          "iftype": "vf",
+          "ihost_uuid": "f73dda8e-be3c-4704-ad1e-ed99e44b846e",
+          "imtu": 1500,
+          "sriov_numvfs": 4,
+          "sriov_vf_driver": "netdevice",
+          "sriov_vf_channels": 4,
+          "uses": ["sriov0"],
+          "usesmodify": [],
+          "ptp_role": "none"
+        }`)
+
+		w.WriteHeader(http.StatusAccepted)
+		w.Header().Add("Content-Type", "application/json")
+		fmt.Fprintf(w, VFChannelsInterfaceSingleBody)
+	})
+}
+
+func HandleChannelsInterfaceUpdateSuccessfully(t *testing.T) {
+	th.Mux.HandleFunc("/iinterfaces/d1e2f3a4-b5c6-7890-abcd-ef1234567890", func(w http.ResponseWriter, r *http.Request) {
+		th.TestMethod(t, r, "PATCH")
+		th.TestHeader(t, r, "X-Auth-Token", client.TokenID)
+		th.TestHeader(t, r, "Accept", "application/json")
+		th.TestHeader(t, r, "Content-Type", "application/json")
+		th.TestJSONRequestUnordered(t, r, `[ { "op": "replace", "path": "/channels", "value": 8 } ]`)
+		fmt.Fprintf(w, ChannelsInterfaceSingleBody)
+	})
+}

--- a/starlingx/inventory/v1/interfaces/testing/requests_test.go
+++ b/starlingx/inventory/v1/interfaces/testing/requests_test.go
@@ -233,3 +233,84 @@ func TestUpdateOVSAccessInterface(t *testing.T) {
 	}
 	th.CheckDeepEquals(t, OVSAccessInterfaceExpected, *actual)
 }
+
+func TestCreateChannelsInterface(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleChannelsInterfaceCreationSuccessfully(t)
+
+	interfaceHostID := "f73dda8e-be3c-4704-ad1e-ed99e44b846e"
+	interfaceName := "pxeboot0"
+	interfaceType := interfaces.IFTypeEthernet
+	interfaceClass := interfaces.IFClassPlatform
+	interfaceMTU := 9000
+	interfaceUses := []string{}
+	interfaceUsers := []string{}
+	ptpRole := interfaces.PTPRoleNone
+	channels := 8
+
+	actual, err := interfaces.Create(client.ServiceClient(), interfaces.InterfaceOpts{
+		HostUUID:   &interfaceHostID,
+		Type:       &interfaceType,
+		Name:       &interfaceName,
+		Class:      &interfaceClass,
+		MTU:        &interfaceMTU,
+		Uses:       &interfaceUses,
+		UsesModify: &interfaceUsers,
+		PTPRole:    &ptpRole,
+		PFChannels: &channels,
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, ChannelsInterfaceExpected, *actual)
+}
+
+func TestCreateVFChannelsInterface(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleVFChannelsInterfaceCreationSuccessfully(t)
+
+	interfaceHostID := "f73dda8e-be3c-4704-ad1e-ed99e44b846e"
+	interfaceName := "sriov-netdev0"
+	interfaceType := interfaces.IFTypeVF
+	interfaceClass := interfaces.IFClassPCISRIOV
+	interfaceMTU := 1500
+	interfaceUses := []string{"sriov0"}
+	interfaceUsers := []string{}
+	ptpRole := interfaces.PTPRoleNone
+	vfCount := 4
+	vfDriver := "netdevice"
+	vfChannels := 4
+
+	actual, err := interfaces.Create(client.ServiceClient(), interfaces.InterfaceOpts{
+		HostUUID:   &interfaceHostID,
+		Type:       &interfaceType,
+		Name:       &interfaceName,
+		Class:      &interfaceClass,
+		MTU:        &interfaceMTU,
+		Uses:       &interfaceUses,
+		UsesModify: &interfaceUsers,
+		PTPRole:    &ptpRole,
+		VFCount:    &vfCount,
+		VFDriver:   &vfDriver,
+		VFChannels: &vfChannels,
+	}).Extract()
+	th.AssertNoErr(t, err)
+
+	th.CheckDeepEquals(t, VFChannelsInterfaceExpected, *actual)
+}
+
+func TestUpdateChannelsInterface(t *testing.T) {
+	th.SetupHTTP()
+	defer th.TeardownHTTP()
+	HandleChannelsInterfaceUpdateSuccessfully(t)
+
+	channels := 8
+	actual, err := interfaces.Update(client.ServiceClient(),
+		"d1e2f3a4-b5c6-7890-abcd-ef1234567890",
+		interfaces.InterfaceOpts{PFChannels: &channels}).Extract()
+	if err != nil {
+		t.Fatalf("Unexpected Update error: %v", err)
+	}
+	th.CheckDeepEquals(t, ChannelsInterfaceExpected, *actual)
+}


### PR DESCRIPTION
Add the pfchannels and vfchannels integer fields to the Interface struct for reading the chanenls values from the sysinv API, and to InterfaceOpts for setting those during interface create and update operations.

This supports configuring pfchannels and vfchannels access on ethernet interfaces.

Test Plan:
- PASS: successfully executed the request
- PASS: go vet ./... && go test ./... --count=1
